### PR TITLE
Fix #82: Add commit activity filter to project discovery

### DIFF
--- a/entities/GitHub/GitHubDiscoverProjects.php
+++ b/entities/GitHub/GitHubDiscoverProjects.php
@@ -25,16 +25,22 @@ class GitHubDiscoverProjects implements \DiscoverProjectsInterface {
       $loc = GitHubRepository::linesOfCode($repo['full_name']);
       if ($loc < 100000)
         continue;
+      
+      $commits_last_month = GitHubRepository::commitsLastMonth($repo['full_name']);
+      if ($commits_last_month < 25)
+        continue;
+      
       $res[] = [
-        'name'        => 'github:' . $repo['full_name'],
-        'description' => $repo['description'],
-        'url'         => $repo['html_url'],
-        'stars'       => format_big_number($repo['stargazers_count']),
-        'loc'         => format_big_number($loc),
-        'open_issues' => format_big_number($repo['open_issues']),
-        'language'    => $repo['language'],
-        'topics'      => $repo['topics'],
-        'last_push'   => github_parse_date($repo['pushed_at']),
+        'name'               => 'github:' . $repo['full_name'],
+        'description'        => $repo['description'],
+        'url'                => $repo['html_url'],
+        'stars'              => format_big_number($repo['stargazers_count']),
+        'loc'                => format_big_number($loc),
+        'open_issues'        => format_big_number($repo['open_issues']),
+        'language'           => $repo['language'],
+        'topics'             => $repo['topics'],
+        'last_push'          => github_parse_date($repo['pushed_at']),
+        'commits_last_month' => format_big_number($commits_last_month),
       ];
     }
 

--- a/templates/discover.html.twig
+++ b/templates/discover.html.twig
@@ -44,6 +44,7 @@
                   <ul class="list-group list-group-flush mt-auto">
                     <li class="list-group-item"><span class="fw-semibold">Language:</span> {{ project.language }}</li>
                     <li class="list-group-item"><span class="fw-semibold">Lines of code:</span> {{ project.loc }}</li>
+                    <li class="list-group-item"><span class="fw-semibold">Commits (last month):</span> {{ project.commits_last_month }}</li>
                     <li class="list-group-item"><span class="fw-semibold">Stars:</span> {{ project.stars }}</li>
                     <li class="list-group-item"><span class="fw-semibold">Open issues:</span> {{ project.open_issues }}</li>
                     <li class="list-group-item"><span class="fw-semibold">Last commit:</span> {{ project.last_push|time_diff }}</li>


### PR DESCRIPTION
The project discovery page was not filtering by recent commit activity, showing inactive projects. This change requires projects to have at least 25 commits in the last month to appear in discovery results. The monthly commit count is now displayed on each project card to help identify actively maintained projects.