### PR TITLE
Fix #83: return beginner issues without extra filters

### DIFF
--- a/pages/discover.php
+++ b/pages/discover.php
@@ -59,12 +59,16 @@ $fields = [
   'form' => $form->createView(),
 ];
 
+$keywords = $form->get('keywords')->getData() ?? '';
+$language = $form->get('language')->getData() ?? '';
+$have_issues_for_newbies = $form->get('newbies')->getData();
+
 if ($form->isSubmitted() && $form->isValid() &&
-    (strlen($keywords = $form->get('keywords')->getData() ?? '') |
-     strlen($language = $form->get('language')->getData() ?? ''))) {
+    (strlen($keywords) > 0 || strlen($language) > 0 ||
+     $have_issues_for_newbies)) {
   try {
     $projs = DiscoverProjects::searchByKeyword($keywords, $language,
-      $form->get('newbies')->getData());
+      $have_issues_for_newbies);
   } catch (Exception $ex) {
     terminate($ex->getMessage(), 'discover.html.twig', $fields);
   }


### PR DESCRIPTION
The Discover Projects page returned no results when the 'Have issues for beginners' filter was used on its own. Update pages/discover.php so the beginner-issues filter still works when Language and Keywords are left empty. No tests were needed for this issue.