### PR TITLE
Implement PHPUnit test structure with coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ vendor
 .proxies
 .cache
 uploads/*
+coverage/
+.phpunit.cache/

--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,15 @@
     "twig/twig": "*"
   },
   "require-dev": {
-    "symfony/messenger": "*"
+    "symfony/messenger": "*",
+    "phpunit/phpunit": "^11.0",
+    "phpunit/php-invoker": "^5.0"
   },
   "autoload": {
     "psr-4": {"": "entities"}
+  },
+  "autoload-dev": {
+    "psr-4": {"Tests\\": "tests"}
   },
   "config": {
     "optimize-autoloader": true,

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.0/phpunit.xsd"
+         bootstrap="tests/bootstrap.php"
+         cacheDirectory=".phpunit.cache"
+         colors="true"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutTestsThatDoNotTestAnything="true"
+         failOnRisky="true"
+         failOnWarning="true">
+    <testsuites>
+        <testsuite name="Unit Tests">
+            <directory>tests/Unit</directory>
+        </testsuite>
+        <testsuite name="Integration Tests">
+            <directory>tests/Integration</directory>
+        </testsuite>
+        <testsuite name="End-to-End Tests">
+            <directory>tests/EndToEnd</directory>
+        </testsuite>
+    </testsuites>
+
+    <source>
+        <include>
+            <directory>entities</directory>
+            <directory>pages</directory>
+        </include>
+        <exclude>
+            <directory>vendor</directory>
+        </exclude>
+    </source>
+
+    <coverage>
+        <report>
+            <html outputDirectory="coverage/"/>
+            <text outputFile="php://stdout"/>
+            <clover outputFile="coverage/clover.xml"/>
+        </report>
+    </coverage>
+</phpunit>

--- a/scripts/run-coverage.sh
+++ b/scripts/run-coverage.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Script to generate code coverage reports
+
+set -e
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+echo "Generating code coverage reports..."
+
+mkdir -p coverage
+
+vendor/bin/phpunit --coverage-html coverage/ --coverage-clover coverage/clover.xml --coverage-text
+
+echo ""
+echo "Coverage report generated."
+echo ""
+echo "Coverage Summary:"
+echo "   - HTML Report: open coverage/index.html"
+echo "   - Clover XML:  coverage/clover.xml"
+echo ""

--- a/scripts/run-tests-fast.sh
+++ b/scripts/run-tests-fast.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Script to run tests without generating coverage reports
+
+set -e
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+vendor/bin/phpunit --no-coverage

--- a/tests/EndToEnd/Base/WebTestCase.php
+++ b/tests/EndToEnd/Base/WebTestCase.php
@@ -1,0 +1,554 @@
+<?php
+
+namespace Tests\EndToEnd\Base;
+
+use Symfony\Component\HttpClient\HttpClient;
+use Tests\Unit\Base\UnitTestCase;
+
+/**
+ * Base class for end-to-end tests that run the full web application
+ * 
+ * Provides isolated app environment with web server and real database
+ */
+abstract class WebTestCase extends UnitTestCase
+{
+    protected static $serverProcess;
+    protected static string $appRoot;
+    protected static string $baseUrl;
+    protected static string $dbPath;
+    protected static array $serverPipes = [];
+    protected static string $githubPrependFile;
+    protected static string $serverLogPath;
+    protected static int $checkedServerLogBytes = 0;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        self::$appRoot = sys_get_temp_dir() . '/pic1_e2e_' . bin2hex(random_bytes(4));
+        self::$dbPath = self::$appRoot . '/db.sqlite';
+        self::$serverLogPath = self::$appRoot . '/server.log';
+        self::$checkedServerLogBytes = 0;
+
+        try {
+            self::createIsolatedAppRoot();
+            self::$baseUrl = 'http://127.0.0.1:' . self::findFreePort();
+            self::$githubPrependFile = dirname(__DIR__) . '/FakeGithubClientPrepend.php';
+            self::startServer();
+        } catch (\Throwable $exception) {
+            self::stopServer();
+            self::removeDirectory(self::$appRoot);
+            throw $exception;
+        }
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        self::stopServer();
+        self::removeDirectory(self::$appRoot);
+
+        parent::tearDownAfterClass();
+    }
+
+    protected function tearDown(): void
+    {
+        $log = file_exists(self::$serverLogPath)
+            ? (string)file_get_contents(self::$serverLogPath)
+            : '';
+        $newLog = substr($log, self::$checkedServerLogBytes);
+        self::$checkedServerLogBytes = strlen($log);
+
+        parent::tearDown();
+
+        $this->assertDoesNotMatchRegularExpression(
+            '/PHP (?:Warning|Notice|Deprecated|Fatal error|Parse error|Uncaught)/',
+            $newLog,
+            "PHP runtime diagnostic in the E2E web server log:\n" . $newLog
+        );
+    }
+
+    protected static function findFreePort(): int
+    {
+        $socket = stream_socket_server('tcp://127.0.0.1:0');
+        if ($socket === false) {
+            throw new \RuntimeException('Could not find a free local port for the end-to-end test server.');
+        }
+
+        $name = stream_socket_get_name($socket, false);
+        fclose($socket);
+
+        return (int)substr(strrchr($name, ':'), 1);
+    }
+
+    private static function startServer(): void
+    {
+        $descriptorSpec = [
+            0 => ['pipe', 'r'],
+            1 => ['file', self::$serverLogPath, 'a'],
+            2 => ['file', self::$serverLogPath, 'a'],
+        ];
+
+        self::$serverProcess = proc_open(
+            [
+                PHP_BINARY,
+                '-d',
+                'auto_prepend_file=' . self::$githubPrependFile,
+                '-S',
+                parse_url(self::$baseUrl, PHP_URL_HOST) . ':' . parse_url(self::$baseUrl, PHP_URL_PORT),
+            ],
+            $descriptorSpec,
+            self::$serverPipes,
+            self::$appRoot
+        );
+
+        if (!is_resource(self::$serverProcess)) {
+            throw new \RuntimeException('Could not start the PHP end-to-end test server.');
+        }
+
+        fclose(self::$serverPipes[0]);
+        self::$serverPipes = [];
+
+        $client = HttpClient::create(['max_redirects' => 0]);
+        $deadline = microtime(true) + 5;
+        do {
+            try {
+                $client->request('GET', self::$baseUrl . '/index.php')->getStatusCode();
+                return;
+            } catch (\Throwable) {
+                usleep(100000);
+            }
+        } while (microtime(true) < $deadline);
+
+        $log = file_exists(self::$serverLogPath) ? trim((string)file_get_contents(self::$serverLogPath)) : '';
+        $detail = $log === '' ? '' : "\nServer log:\n" . $log;
+        throw new \RuntimeException('The PHP end-to-end test server did not become ready.' . $detail);
+    }
+
+    private static function stopServer(): void
+    {
+        foreach (self::$serverPipes as $pipe) {
+            if (is_resource($pipe)) {
+                fclose($pipe);
+            }
+        }
+        self::$serverPipes = [];
+
+        if (is_resource(self::$serverProcess ?? null)) {
+            proc_terminate(self::$serverProcess);
+            proc_close(self::$serverProcess);
+            self::$serverProcess = null;
+        }
+    }
+
+    protected static function pdo(): \PDO
+    {
+        $pdo = new \PDO('sqlite:' . self::$dbPath);
+        $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+        $pdo->setAttribute(\PDO::ATTR_TIMEOUT, 1);
+        $pdo->exec('PRAGMA busy_timeout=1000;');
+        $pdo->exec('PRAGMA foreign_keys=ON;');
+
+        return $pdo;
+    }
+
+    private static function createIsolatedAppRoot(): void
+    {
+        mkdir(self::$appRoot, 0777, true);
+        mkdir(self::$appRoot . '/.cache/twig', 0777, true);
+        mkdir(self::$appRoot . '/uploads', 0777, true);
+
+        foreach (['assets', 'entities', 'pages', 'templates'] as $directory) {
+            self::copyDirectory(dirname(__DIR__, 3) . '/' . $directory, self::$appRoot . '/' . $directory);
+        }
+
+        foreach ([
+            'auth.php',
+            'config.php',
+            'db.php',
+            'fenix.php',
+            'github.php',
+            'include.php',
+            'index.php',
+            'logout.php',
+            'review.php',
+            'templates.php',
+            'validation.php',
+            'video.php',
+        ] as $file) {
+            copy(dirname(__DIR__, 3) . '/' . $file, self::$appRoot . '/' . $file);
+        }
+
+        symlink(dirname(__DIR__, 3) . '/vendor', self::$appRoot . '/vendor');
+        copy(dirname(__DIR__, 3) . '/db.sqlite', self::$dbPath);
+        $pdo = new \PDO('sqlite:' . self::$dbPath);
+        $pdo->exec('PRAGMA journal_mode=WAL;');
+        $pdo->exec('PRAGMA busy_timeout=1000;');
+        $pdo = null;
+    }
+
+    protected static function copyDirectory(string $source, string $target): void
+    {
+        mkdir($target, 0777, true);
+        $items = scandir($source);
+        if ($items === false) {
+            throw new \RuntimeException("Could not read directory: $source");
+        }
+
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+
+            $from = $source . '/' . $item;
+            $to = $target . '/' . $item;
+
+            if (is_dir($from)) {
+                self::copyDirectory($from, $to);
+            } else {
+                copy($from, $to);
+            }
+        }
+    }
+
+    protected static function removeDirectory(string $path): void
+    {
+        if (!is_dir($path)) {
+            return;
+        }
+
+        $items = scandir($path);
+        if ($items === false) {
+            return;
+        }
+
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+
+            $fullPath = $path . '/' . $item;
+            if (is_dir($fullPath) && !is_link($fullPath)) {
+                self::removeDirectory($fullPath);
+            } else {
+                @unlink($fullPath);
+            }
+        }
+
+        @rmdir($path);
+    }
+
+    protected static function insertUser(array $data): void
+    {
+        $pdo = self::pdo();
+        $stmt = $pdo->prepare(
+            'INSERT INTO User (id, name, email, photo, role, repository_user, repository_etag, repository_last_processed_id)
+             VALUES (:id, :name, :email, :photo, :role, :repository_user, :repository_etag, :repository_last_processed_id)'
+        );
+        $stmt->execute($data);
+        $stmt = null;
+        $pdo = null;
+    }
+
+    protected static function insertSession(
+        string $sessionId,
+        string $userId,
+        string $expires = '+1 day'
+    ): void
+    {
+        $pdo = self::pdo();
+        $stmt = $pdo->prepare(
+            'INSERT INTO Session (id, expires, user_id) VALUES (:id, :expires, :user_id)'
+        );
+        $stmt->execute([
+            'id' => $sessionId,
+            'expires' => (new \DateTimeImmutable($expires))->format('Y-m-d H:i:s'),
+            'user_id' => $userId,
+        ]);
+        $stmt = null;
+        $pdo = null;
+    }
+
+    protected static function deleteSessionAndUser(string $sessionId, string $userId): void
+    {
+        $pdo = self::pdo();
+        $stmt = $pdo->prepare('DELETE FROM Session WHERE id = :id');
+        $stmt->execute(['id' => $sessionId]);
+        $stmt = $pdo->prepare('DELETE FROM User WHERE id = :id');
+        $stmt->execute(['id' => $userId]);
+        $stmt = null;
+        $pdo = null;
+    }
+
+    protected static function insertShift(string $name, int $year, ?string $profId): int
+    {
+        $pdo = self::pdo();
+        $stmt = $pdo->prepare(
+            'INSERT INTO Shift (name, year, prof_id) VALUES (:name, :year, :prof_id)'
+        );
+        $stmt->execute([
+            'name' => $name,
+            'year' => $year,
+            'prof_id' => $profId,
+        ]);
+        $id = (int)$pdo->lastInsertId();
+        $stmt = null;
+        $pdo = null;
+
+        return $id;
+    }
+
+    protected static function insertGroup(int $groupNumber, int $year, int $shiftId): int
+    {
+        $pdo = self::pdo();
+        $stmt = $pdo->prepare(
+            'INSERT INTO ProjGroup (
+                group_number, year, project_name, project_description, project_website,
+                repository, cla, dco, major_users, coding_style, bugs_for_beginners,
+                project_ideas, student_programs, getting_started_manual,
+                developers_manual, testing_manual, developers_mailing_list,
+                patch_submission, hash_proposal_file, url_proposal, hash_final_report,
+                allow_modifications_date, shift_id
+             ) VALUES (
+                :group_number, :year, :project_name, :project_description, :project_website,
+                :repository, :cla, :dco, :major_users, :coding_style, :bugs_for_beginners,
+                :project_ideas, :student_programs, :getting_started_manual,
+                :developers_manual, :testing_manual, :developers_mailing_list,
+                :patch_submission, :hash_proposal_file, :url_proposal, :hash_final_report,
+                :allow_modifications_date, :shift_id
+             )'
+        );
+        $stmt->execute([
+            'group_number' => $groupNumber,
+            'year' => $year,
+            'project_name' => 'E2E Project ' . $groupNumber,
+            'project_description' => 'End-to-end test project',
+            'project_website' => 'https://example.org/project',
+            'repository' => '',
+            'cla' => 0,
+            'dco' => 0,
+            'major_users' => '',
+            'coding_style' => 'https://example.org/style',
+            'bugs_for_beginners' => 'https://example.org/bugs',
+            'project_ideas' => 'https://example.org/ideas',
+            'student_programs' => '',
+            'getting_started_manual' => 'https://example.org/start',
+            'developers_manual' => 'https://example.org/dev',
+            'testing_manual' => 'https://example.org/test',
+            'developers_mailing_list' => 'https://example.org/list',
+            'patch_submission' => 'https://example.org/patch',
+            'hash_proposal_file' => '',
+            'url_proposal' => '',
+            'hash_final_report' => '',
+            'allow_modifications_date' => (new \DateTimeImmutable('+2 days'))->format('Y-m-d H:i:s'),
+            'shift_id' => $shiftId,
+        ]);
+        $id = (int)$pdo->lastInsertId();
+        $stmt = null;
+        $pdo = null;
+
+        return $id;
+    }
+
+    protected static function insertGroupMembership(int $groupId, string $userId): void
+    {
+        $pdo = self::pdo();
+        $stmt = $pdo->prepare(
+            'INSERT INTO projgroup_user (projgroup_id, user_id) VALUES (:projgroup_id, :user_id)'
+        );
+        $stmt->execute([
+            'projgroup_id' => $groupId,
+            'user_id' => $userId,
+        ]);
+        $stmt = null;
+        $pdo = null;
+    }
+
+    protected static function upsertDeadline(int $year, string $finalReportOffset): void
+    {
+        $pdo = self::pdo();
+        $deadline = [
+            'year' => $year,
+            'proj_proposal' => (new \DateTimeImmutable('-1 day'))->format('Y-m-d H:i:s'),
+            'bug_selection' => (new \DateTimeImmutable('-1 day'))->format('Y-m-d H:i:s'),
+            'feature_selection' => (new \DateTimeImmutable('-1 day'))->format('Y-m-d H:i:s'),
+            'patch_submission' => (new \DateTimeImmutable('-1 day'))->format('Y-m-d H:i:s'),
+            'final_report' => (new \DateTimeImmutable($finalReportOffset))->format('Y-m-d H:i:s'),
+        ];
+
+        $exists = $pdo->prepare('SELECT COUNT(*) FROM Deadline WHERE year = :year');
+        $exists->execute(['year' => $year]);
+        if ((int)$exists->fetchColumn() > 0) {
+            $stmt = $pdo->prepare(
+                'UPDATE Deadline
+                 SET proj_proposal = :proj_proposal,
+                     bug_selection = :bug_selection,
+                     feature_selection = :feature_selection,
+                     patch_submission = :patch_submission,
+                     final_report = :final_report
+                 WHERE year = :year'
+            );
+            $stmt->execute($deadline);
+            $stmt = null;
+            $exists = null;
+            $pdo = null;
+            return;
+        }
+
+        $stmt = $pdo->prepare(
+            'INSERT INTO Deadline (year, proj_proposal, bug_selection, feature_selection, patch_submission, final_report)
+             VALUES (:year, :proj_proposal, :bug_selection, :feature_selection, :patch_submission, :final_report)'
+        );
+        $stmt->execute($deadline);
+        $stmt = null;
+        $exists = null;
+        $pdo = null;
+    }
+
+    protected static function createTemporaryPdf(string $prefix): string
+    {
+        $path = tempnam(sys_get_temp_dir(), 'pic1_' . $prefix . '_');
+        $pdfPath = $path . '.pdf';
+        rename($path, $pdfPath);
+        file_put_contents(
+            $pdfPath,
+            "%PDF-1.4\n1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n2 0 obj\n<< /Type /Pages /Count 0 >>\nendobj\ntrailer\n<< /Root 1 0 R >>\n%%EOF\n"
+        );
+
+        return $pdfPath;
+    }
+
+    protected static function deleteGroupFixture(
+        array $groupIds,
+        int $shiftId,
+        array $userIds,
+        array $sessionIds,
+        int $year
+    ): void {
+        $pdo = self::pdo();
+        foreach ($groupIds as $groupId) {
+            $pdo->prepare('DELETE FROM projgroup_user WHERE projgroup_id = :projgroup_id')
+                ->execute(['projgroup_id' => $groupId]);
+            $pdo->prepare('DELETE FROM ProjGroup WHERE id = :id')->execute(['id' => $groupId]);
+        }
+        $pdo->prepare('DELETE FROM Shift WHERE id = :id')->execute(['id' => $shiftId]);
+        foreach ($sessionIds as $sessionId) {
+            $pdo->prepare('DELETE FROM Session WHERE id = :id')->execute(['id' => $sessionId]);
+        }
+        foreach ($userIds as $userId) {
+            $pdo->prepare('DELETE FROM User WHERE id = :id')->execute(['id' => $userId]);
+        }
+        $pdo->prepare('DELETE FROM Deadline WHERE year = :year')->execute(['year' => $year]);
+    }
+
+    protected static function insertMilestone(
+        int $year,
+        string $name,
+        string $description,
+        string $field1,
+        int $points1,
+        int $range1
+    ): int {
+        $pdo = self::pdo();
+        $stmt = $pdo->prepare(
+            'INSERT INTO Milestone (
+                year, name, description, page, individual,
+                field1, points1, range1, field2, points2, range2,
+                field3, points3, range3, field4, points4, range4
+             ) VALUES (
+                :year, :name, :description, :page, :individual,
+                :field1, :points1, :range1, :field2, :points2, :range2,
+                :field3, :points3, :range3, :field4, :points4, :range4
+             )'
+        );
+        $stmt->execute([
+            'year' => $year,
+            'name' => $name,
+            'description' => $description,
+            'page' => 'grades',
+            'individual' => 0,
+            'field1' => $field1,
+            'points1' => $points1,
+            'range1' => $range1,
+            'field2' => '',
+            'points2' => 0,
+            'range2' => 0,
+            'field3' => '',
+            'points3' => 0,
+            'range3' => 0,
+            'field4' => '',
+            'points4' => 0,
+            'range4' => 0,
+        ]);
+        $id = (int)$pdo->lastInsertId();
+        $stmt = null;
+        $pdo = null;
+
+        return $id;
+    }
+
+    protected static function insertFinalGrade(int $year, string $formula): void
+    {
+        $pdo = self::pdo();
+        $stmt = $pdo->prepare(
+            'INSERT INTO FinalGrade (year, formula) VALUES (:year, :formula)'
+        );
+        $stmt->execute([
+            'year' => $year,
+            'formula' => $formula,
+        ]);
+        $stmt = null;
+        $pdo = null;
+    }
+
+    protected static function insertGrade(string $userId, int $milestoneId, int $field1, int $lateDays): void
+    {
+        $pdo = self::pdo();
+        $stmt = $pdo->prepare(
+            'INSERT INTO Grade (field1, field2, field3, field4, late_days, user_id, milestone_id)
+             VALUES (:field1, NULL, NULL, NULL, :late_days, :user_id, :milestone_id)'
+        );
+        $stmt->execute([
+            'field1' => $field1,
+            'late_days' => $lateDays,
+            'user_id' => $userId,
+            'milestone_id' => $milestoneId,
+        ]);
+        $stmt = null;
+        $pdo = null;
+    }
+
+    protected static function deleteGradesFixture(
+        int $year,
+        int $milestoneId,
+        array $studentIds,
+        array $groupIds,
+        int $shiftId,
+        string $professorId,
+        string $professorSessionId
+    ): void {
+        $pdo = self::pdo();
+        foreach ($studentIds as $studentId) {
+            $pdo->prepare('DELETE FROM Grade WHERE user_id = :user_id')->execute(['user_id' => $studentId]);
+        }
+        $pdo->prepare('DELETE FROM FinalGrade WHERE year = :year')->execute(['year' => $year]);
+        $pdo->prepare('DELETE FROM Milestone WHERE id = :id')->execute(['id' => $milestoneId]);
+        $pdo->prepare('DELETE FROM Deadline WHERE year = :year')->execute(['year' => $year]);
+        foreach ($groupIds as $groupId) {
+            $pdo->prepare('DELETE FROM projgroup_user WHERE projgroup_id = :projgroup_id')
+                ->execute(['projgroup_id' => $groupId]);
+            $pdo->prepare('DELETE FROM ProjGroup WHERE id = :id')->execute(['id' => $groupId]);
+        }
+        $pdo->prepare('DELETE FROM Shift WHERE id = :id')->execute(['id' => $shiftId]);
+        $pdo->prepare('DELETE FROM Session WHERE id = :id')->execute(['id' => $professorSessionId]);
+        foreach (array_merge([$professorId], $studentIds) as $userId) {
+            $pdo->prepare('DELETE FROM User WHERE id = :id')->execute(['id' => $userId]);
+        }
+    }
+
+    protected function request(string $method, string $path, array $options = [])
+    {
+        $client = HttpClient::create(['max_redirects' => 0]);
+
+        return $client->request($method, self::$baseUrl . $path, $options);
+    }
+}

--- a/tests/EndToEnd/FakeGithubClientPrepend.php
+++ b/tests/EndToEnd/FakeGithubClientPrepend.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Github;
+
+/*
+ * Loaded through auto_prepend_file inside the PHP web-server process. This
+ * must define Github\Client before Composer loads the real client; regular
+ * test mocks only replace globals in the PHPUnit process.
+ */
+if (!class_exists(Client::class, false)) {
+    class FakeUserApi
+    {
+        public function show(string $username): array
+        {
+            return [
+                'login' => $username,
+                'id' => 1000,
+                'name' => ucwords(str_replace(['-', '_'], ' ', $username)),
+                'email' => $username . '@example.com',
+                'company' => 'Open Source Lab',
+                'location' => 'Lisbon, Portugal',
+            ];
+        }
+    }
+
+    class Client
+    {
+        public function __construct(...$args)
+        {
+        }
+
+        public function authenticate(...$args): void
+        {
+        }
+
+        public function api(string $endpoint): object
+        {
+            if ($endpoint === 'user') {
+                return new FakeUserApi();
+            }
+
+            return new class {
+            };
+        }
+    }
+}

--- a/tests/EndToEnd/WebAppEndToEndTest.php
+++ b/tests/EndToEnd/WebAppEndToEndTest.php
@@ -1,0 +1,483 @@
+<?php
+
+namespace Tests\EndToEnd;
+
+use Tests\EndToEnd\Base\WebTestCase;
+
+class WebAppEndToEndTest extends WebTestCase
+{
+    private static ?string $studentId = null;
+    private static ?string $studentSessionId = null;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createStudentSession();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        self::deleteStudentSession();
+        parent::tearDownAfterClass();
+    }
+
+    public function testUnauthenticatedRequestRedirectsToFenixLogin(): void
+    {
+        $response = $this->request('GET', '/index.php?page=profile');
+
+        $this->assertSame(302, $response->getStatusCode());
+        $this->assertStringContainsString(
+            'fenix.tecnico.ulisboa.pt/oauth/userdialog',
+            $response->getHeaders(false)['location'][0] ?? ''
+        );
+    }
+
+    public function testExpiredStudentSessionRedirectsToFenixLogin(): void
+    {
+        $sessionId = bin2hex(random_bytes(16));
+        self::insertSession($sessionId, self::$studentId, '-1 day');
+
+        try {
+            $response = $this->request(
+                'GET',
+                '/index.php?page=profile',
+                ['headers' => ['Cookie' => 'sessid=' . $sessionId]]
+            );
+
+            $this->assertSame(302, $response->getStatusCode());
+            $this->assertStringContainsString(
+                'fenix.tecnico.ulisboa.pt/oauth/userdialog',
+                $response->getHeaders(false)['location'][0] ?? ''
+            );
+        } finally {
+            self::pdo()->prepare('DELETE FROM Session WHERE id = :id')
+                ->execute(['id' => $sessionId]);
+        }
+    }
+
+    public function testAuthenticatedStudentCanOpenProfilePage(): void
+    {
+        $response = $this->request(
+            'GET',
+            '/index.php?page=profile',
+            ['headers' => ['Cookie' => $this->studentCookie()]]
+        );
+        $html = $response->getContent();
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertStringContainsString('<title>PIC1: Edit profile</title>', $html);
+        $this->assertStringContainsString('E2E Student', $html);
+        $this->assertStringContainsString('User ID: ' . self::$studentId, $html);
+        $this->assertStringContainsString('name="form[repository_user]"', $html);
+    }
+
+    public function testAuthenticatedStudentCanUpdateRepositoryUserOnProfilePage(): void
+    {
+        $studentId = 'e2eprof' . substr(bin2hex(random_bytes(4)), 0, 8);
+        $sessionId = bin2hex(random_bytes(16));
+
+        self::insertUser([
+            'id' => $studentId,
+            'name' => 'Profile Student',
+            'email' => 'profile@example.com',
+            'photo' => '',
+            'role' => ROLE_STUDENT,
+            'repository_user' => '',
+            'repository_etag' => '',
+            'repository_last_processed_id' => '0',
+        ]);
+        self::insertSession($sessionId, $studentId);
+        gc_collect_cycles();
+
+        try {
+            $response = $this->request(
+                'POST',
+                '/index.php?page=profile',
+                [
+                    'headers' => ['Cookie' => 'sessid=' . $sessionId],
+                    'body' => [
+                        'form' => [
+                            'repository_user' => 'github:alice-student',
+                            'submit' => '',
+                        ],
+                    ],
+                ]
+            );
+            $html = $response->getContent();
+
+            $this->assertSame(200, $response->getStatusCode());
+            $this->assertStringContainsString('Database updated!', $html);
+            $this->assertStringContainsString('github:alice-student', $html);
+            $this->assertStringContainsString('https://github.com/alice-student', $html);
+            $this->assertStringContainsString('Open Source Lab', $html);
+
+            $stmt = self::pdo()->prepare('SELECT repository_user FROM User WHERE id = :id');
+            $stmt->execute(['id' => $studentId]);
+            $repositoryUser = $stmt->fetchColumn();
+            $this->assertSame('github:alice-student', $repositoryUser);
+        } finally {
+            self::deleteSessionAndUser($sessionId, $studentId);
+        }
+    }
+
+    public function testStudentCannotOpenProfessorOnlyPage(): void
+    {
+        $response = $this->request(
+            'GET',
+            '/index.php?page=shifts',
+            ['headers' => ['Cookie' => $this->studentCookie()]]
+        );
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('Unauthorized access', trim($response->getContent()));
+    }
+
+    public function testStudentCannotOpenDeadlinesPage(): void
+    {
+        $response = $this->request(
+            'GET',
+            '/index.php?page=deadlines',
+            ['headers' => ['Cookie' => $this->studentCookie()]]
+        );
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('Unauthorized access', trim($response->getContent()));
+    }
+
+    public function testStudentCannotOpenGradingPage(): void
+    {
+        $response = $this->request(
+            'GET',
+            '/index.php?page=grading',
+            ['headers' => ['Cookie' => $this->studentCookie()]]
+        );
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('Unauthorized access', trim($response->getContent()));
+    }
+
+    public function testStudentCannotOpenChangeRolePage(): void
+    {
+        $response = $this->request(
+            'GET',
+            '/index.php?page=changerole',
+            ['headers' => ['Cookie' => $this->studentCookie()]]
+        );
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('Unauthorized access', trim($response->getContent()));
+    }
+
+    public function testStudentCannotOpenImpersonatePage(): void
+    {
+        $response = $this->request(
+            'GET',
+            '/index.php?page=impersonate',
+            ['headers' => ['Cookie' => $this->studentCookie()]]
+        );
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('Unauthorized access', trim($response->getContent()));
+    }
+
+    public function testStudentCannotOpenCronPage(): void
+    {
+        $response = $this->request(
+            'GET',
+            '/index.php?page=cron',
+            ['headers' => ['Cookie' => $this->studentCookie()]]
+        );
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('Unauthorized access', trim($response->getContent()));
+    }
+
+    public function testStudentCannotOpenRmpatchPage(): void
+    {
+        $response = $this->request(
+            'GET',
+            '/index.php?page=rmpatch',
+            ['headers' => ['Cookie' => $this->studentCookie()]]
+        );
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('Unauthorized access', trim($response->getContent()));
+    }
+
+    public function testAuthenticatedRequestToUnknownPageReturnsInvalidPage(): void
+    {
+        $response = $this->request(
+            'GET',
+            '/index.php?page=does-not-exist',
+            ['headers' => ['Cookie' => $this->studentCookie()]]
+        );
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('Invalid page', trim($response->getContent()));
+    }
+
+    public function testAuthenticatedStudentCanUploadAndDownloadFinalReport(): void
+    {
+        $year = get_current_year() + 7;
+        $studentId = 'e2ereport' . substr(bin2hex(random_bytes(4)), 0, 6);
+        $sessionId = bin2hex(random_bytes(16));
+        $otherStudentId = 'e2eother' . substr(bin2hex(random_bytes(4)), 0, 6);
+        $otherSessionId = bin2hex(random_bytes(16));
+        $shiftId = self::insertShift('T1-E2E-REPORT', $year, null);
+        $groupId = self::insertGroup(3101, $year, $shiftId);
+        $otherGroupId = self::insertGroup(3102, $year, $shiftId);
+        $pdfPath = self::createTemporaryPdf('report');
+        $expectedHash = sha1(file_get_contents($pdfPath));
+        $storedPath = self::$appRoot . '/uploads/' . $expectedHash;
+
+        self::insertUser([
+            'id' => $studentId,
+            'name' => 'Report Student',
+            'email' => 'report@example.com',
+            'photo' => '',
+            'role' => ROLE_STUDENT,
+            'repository_user' => '',
+            'repository_etag' => '',
+            'repository_last_processed_id' => '0',
+        ]);
+        self::insertUser([
+            'id' => $otherStudentId,
+            'name' => 'Other Report Student',
+            'email' => 'other.report@example.com',
+            'photo' => '',
+            'role' => ROLE_STUDENT,
+            'repository_user' => '',
+            'repository_etag' => '',
+            'repository_last_processed_id' => '0',
+        ]);
+        self::insertSession($sessionId, $studentId);
+        self::insertSession($otherSessionId, $otherStudentId);
+        self::insertGroupMembership($groupId, $studentId);
+        self::insertGroupMembership($otherGroupId, $otherStudentId);
+        self::upsertDeadline($year, '+1 day');
+        gc_collect_cycles();
+
+        $handle = null;
+        try {
+            $handle = fopen($pdfPath, 'r');
+            stream_context_set_option($handle, 'http', 'content_type', 'application/pdf');
+            $response = $this->request(
+                'POST',
+                '/index.php?page=report',
+                [
+                    'headers' => ['Cookie' => 'sessid=' . $sessionId],
+                    'body' => [
+                        'form' => [
+                            'file' => $handle,
+                            'submit' => '',
+                        ],
+                    ],
+                ]
+            );
+            $html = $response->getContent();
+            $this->assertSame(200, $response->getStatusCode());
+            $this->assertStringContainsString('File uploaded successfully!', $html);
+            $this->assertStringContainsString('index.php?download=' . $groupId . '&amp;page=report', $html);
+
+            $hash = self::pdo()
+                ->query("SELECT hash_final_report FROM ProjGroup WHERE id = $groupId")
+                ->fetchColumn();
+            $this->assertSame($expectedHash, $hash);
+            $this->assertFileExists($storedPath);
+
+            $download = $this->request(
+                'GET',
+                '/index.php?page=report&download=' . $groupId,
+                ['headers' => ['Cookie' => 'sessid=' . $sessionId]]
+            );
+
+            $this->assertSame(200, $download->getStatusCode());
+            $this->assertStringContainsString('application/pdf', $download->getHeaders(false)['content-type'][0] ?? '');
+            $this->assertSame(file_get_contents($storedPath), $download->getContent());
+
+            $forbiddenDownload = $this->request(
+                'GET',
+                '/index.php?page=report&download=' . $groupId,
+                ['headers' => ['Cookie' => 'sessid=' . $otherSessionId]]
+            );
+
+            $this->assertSame(200, $forbiddenDownload->getStatusCode());
+            $this->assertSame('No permissions', trim($forbiddenDownload->getContent()));
+        } finally {
+            if (is_resource($handle)) {
+                fclose($handle);
+            }
+            if (file_exists($pdfPath)) {
+                @unlink($pdfPath);
+            }
+            if (file_exists($storedPath)) {
+                @unlink($storedPath);
+            }
+            self::deleteGroupFixture(
+                [$groupId, $otherGroupId],
+                $shiftId,
+                [$studentId, $otherStudentId],
+                [$sessionId, $otherSessionId],
+                $year
+            );
+        }
+    }
+
+    public function testAuthenticatedProfessorCanViewAndDownloadGrades(): void
+    {
+        $year = get_current_year() + 8;
+        $professorId = 'e2eprofessor' . substr(bin2hex(random_bytes(4)), 0, 6);
+        $professorSessionId = bin2hex(random_bytes(16));
+        $student1Id = 'e2egradea' . substr(bin2hex(random_bytes(3)), 0, 6);
+        $student2Id = 'e2egradeb' . substr(bin2hex(random_bytes(3)), 0, 6);
+
+        self::insertUser([
+            'id' => $professorId,
+            'name' => 'Professor Grades',
+            'email' => 'prof.grades@example.com',
+            'photo' => '',
+            'role' => ROLE_PROF,
+            'repository_user' => '',
+            'repository_etag' => '',
+            'repository_last_processed_id' => '0',
+        ]);
+        self::insertUser([
+            'id' => $student1Id,
+            'name' => 'Alice Student',
+            'email' => 'alice.grades@example.com',
+            'photo' => '',
+            'role' => ROLE_STUDENT,
+            'repository_user' => '',
+            'repository_etag' => '',
+            'repository_last_processed_id' => '0',
+        ]);
+        self::insertUser([
+            'id' => $student2Id,
+            'name' => 'Bob Student',
+            'email' => 'bob.grades@example.com',
+            'photo' => '',
+            'role' => ROLE_STUDENT,
+            'repository_user' => '',
+            'repository_etag' => '',
+            'repository_last_processed_id' => '0',
+        ]);
+        self::insertSession($professorSessionId, $professorId);
+
+        $shiftId = self::insertShift('T1-E2E-GRADES', $year, $professorId);
+        $group1Id = self::insertGroup(1001, $year, $shiftId);
+        $group2Id = self::insertGroup(2001, $year, $shiftId);
+        self::insertGroupMembership($group1Id, $student1Id);
+        self::insertGroupMembership($group2Id, $student2Id);
+        $milestoneId = self::insertMilestone($year, 'M1', 'Milestone One', 'Code Quality', 200, 100);
+        self::insertFinalGrade($year, 'M1');
+        self::insertGrade($student1Id, $milestoneId, 80, 0);
+        self::insertGrade($student2Id, $milestoneId, 50, 6);
+        gc_collect_cycles();
+
+        try {
+            $response = $this->request(
+                'GET',
+                '/index.php?page=grades&year=' . $year . '&all_shifts=1',
+                ['headers' => ['Cookie' => 'sessid=' . $professorSessionId]]
+            );
+            $html = $response->getContent();
+
+            $this->assertSame(200, $response->getStatusCode());
+            $this->assertStringContainsString('<title>PIC1: Grades</title>', $html);
+            $this->assertStringContainsString('Alice Student', $html);
+            $this->assertStringContainsString('Bob Student', $html);
+            $this->assertStringContainsString('Download grades of group 1', $html);
+            $this->assertStringContainsString('Download grades of group 2', $html);
+
+            $passingDownload = $this->request(
+                'GET',
+                '/index.php?page=grades&download=1&all_shifts=1&year=' . $year,
+                ['headers' => ['Cookie' => 'sessid=' . $professorSessionId]]
+            );
+
+            $this->assertSame(200, $passingDownload->getStatusCode());
+            $this->assertStringContainsString(
+                'text/plain',
+                $passingDownload->getHeaders(false)['content-type'][0] ?? ''
+            );
+            $this->assertSame($student1Id . "\t16\n", $passingDownload->getContent());
+
+            $failingDownload = $this->request(
+                'GET',
+                '/index.php?page=grades&download=2&all_shifts=1&year=' . $year,
+                ['headers' => ['Cookie' => 'sessid=' . $professorSessionId]]
+            );
+
+            $this->assertSame(200, $failingDownload->getStatusCode());
+            $this->assertStringContainsString(
+                'text/plain',
+                $failingDownload->getHeaders(false)['content-type'][0] ?? ''
+            );
+            $this->assertSame($student2Id . "\tNA\n", $failingDownload->getContent());
+        } finally {
+            self::deleteGradesFixture(
+                $year,
+                $milestoneId,
+                [$student1Id, $student2Id],
+                [$group1Id, $group2Id],
+                $shiftId,
+                $professorId,
+                $professorSessionId
+            );
+        }
+    }
+
+    private static function createStudentSession(): void
+    {
+        $suffix = substr(bin2hex(random_bytes(4)), 0, 8);
+        self::$studentId = 'e2e' . $suffix;
+        self::$studentSessionId = bin2hex(random_bytes(16));
+
+        $pdo = self::pdo();
+        $pdo->prepare(
+            'INSERT INTO User (id, name, email, photo, role, repository_user, repository_etag, repository_last_processed_id)
+             VALUES (:id, :name, :email, :photo, :role, :repository_user, :repository_etag, :repository_last_processed_id)'
+        )->execute([
+            'id' => self::$studentId,
+            'name' => 'E2E Student',
+            'email' => 'e2e@example.com',
+            'photo' => '',
+            'role' => ROLE_STUDENT,
+            'repository_user' => '',
+            'repository_etag' => '',
+            'repository_last_processed_id' => '0',
+        ]);
+
+        $pdo->prepare(
+            'INSERT INTO Session (id, expires, user_id) VALUES (:id, :expires, :user_id)'
+        )->execute([
+            'id' => self::$studentSessionId,
+            'expires' => (new \DateTimeImmutable('+1 day'))->format('Y-m-d H:i:s'),
+            'user_id' => self::$studentId,
+        ]);
+    }
+
+    private static function deleteStudentSession(): void
+    {
+        if (!self::$studentId && !self::$studentSessionId) {
+            return;
+        }
+
+        $pdo = self::pdo();
+        if (self::$studentSessionId) {
+            $pdo->prepare('DELETE FROM Session WHERE id = :id')
+                ->execute(['id' => self::$studentSessionId]);
+            self::$studentSessionId = null;
+        }
+        if (self::$studentId) {
+            $pdo->prepare('DELETE FROM User WHERE id = :id')
+                ->execute(['id' => self::$studentId]);
+            self::$studentId = null;
+        }
+    }
+
+    private function studentCookie(): string
+    {
+        return 'sessid=' . self::$studentSessionId;
+    }
+}

--- a/tests/Integration/Base/IntegrationTestCase.php
+++ b/tests/Integration/Base/IntegrationTestCase.php
@@ -1,0 +1,433 @@
+<?php
+
+namespace Tests\Integration\Base;
+
+use Tests\Unit\Base\UnitTestCase;
+
+/**
+ * Base class for integration tests that need a mock database
+ * 
+ * Creates isolated SQLite database for each test class
+ */
+abstract class IntegrationTestCase extends UnitTestCase
+{
+    protected static string $dbPath;
+    protected static bool $dbInitialized = false;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        
+        // Create temporary SQLite database
+        self::$dbPath = sys_get_temp_dir() . '/pic1_integration_' . bin2hex(random_bytes(4)) . '.sqlite';
+        self::initializeDatabase();
+        self::$dbInitialized = true;
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        if (file_exists(self::$dbPath)) {
+            @unlink(self::$dbPath);
+        }
+        parent::tearDownAfterClass();
+    }
+
+    protected static function getPdo(): \PDO
+    {
+        $pdo = new \PDO('sqlite:' . self::$dbPath);
+        $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+        $pdo->setAttribute(\PDO::ATTR_TIMEOUT, 1);
+        $pdo->exec('PRAGMA busy_timeout=1000;');
+        $pdo->exec('PRAGMA foreign_keys=ON;');
+        return $pdo;
+    }
+
+    private static function initializeDatabase(): void
+    {
+        $pdo = self::getPdo();
+        
+        // Create User table
+        $pdo->exec('
+            CREATE TABLE IF NOT EXISTS User (
+                id VARCHAR(16) NOT NULL,
+                name VARCHAR(255) NOT NULL,
+                email VARCHAR(255) NOT NULL,
+                photo CLOB NOT NULL,
+                role INTEGER NOT NULL,
+                repository_user VARCHAR(255) NOT NULL,
+                repository_etag VARCHAR(255) NOT NULL,
+                repository_last_processed_id BIGINT NOT NULL,
+                PRIMARY KEY (id)
+            )
+        ');
+
+        // Create Session table
+        $pdo->exec('
+            CREATE TABLE IF NOT EXISTS Session (
+                id VARCHAR(32) NOT NULL,
+                expires DATETIME NOT NULL,
+                user_id VARCHAR(16) DEFAULT NULL,
+                PRIMARY KEY (id),
+                CONSTRAINT FK_1FF9EC48A76ED395 FOREIGN KEY (user_id) REFERENCES User (id)
+            )
+        ');
+
+        // Create Shift table
+        $pdo->exec('
+            CREATE TABLE IF NOT EXISTS Shift (
+                id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                name VARCHAR(255) NOT NULL,
+                year INTEGER NOT NULL,
+                prof_id VARCHAR(16) DEFAULT NULL,
+                CONSTRAINT FK_64CA1441ABC1F7FE FOREIGN KEY (prof_id) REFERENCES User (id)
+            )
+        ');
+
+        // Create ProjGroup table
+        $pdo->exec('
+            CREATE TABLE IF NOT EXISTS ProjGroup (
+                id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                group_number INTEGER NOT NULL,
+                year INTEGER NOT NULL,
+                project_name VARCHAR(255) NOT NULL,
+                project_description VARCHAR(2000) NOT NULL,
+                project_website VARCHAR(255) NOT NULL,
+                repository VARCHAR(150) NOT NULL,
+                cla BOOLEAN NOT NULL,
+                dco BOOLEAN NOT NULL,
+                major_users VARCHAR(255) NOT NULL,
+                coding_style VARCHAR(255) NOT NULL,
+                bugs_for_beginners VARCHAR(255) NOT NULL,
+                project_ideas VARCHAR(255) NOT NULL,
+                student_programs VARCHAR(1000) NOT NULL,
+                getting_started_manual VARCHAR(255) NOT NULL,
+                developers_manual VARCHAR(255) NOT NULL,
+                testing_manual VARCHAR(255) NOT NULL,
+                developers_mailing_list VARCHAR(255) NOT NULL,
+                patch_submission VARCHAR(255) NOT NULL,
+                hash_proposal_file VARCHAR(40) NOT NULL,
+                url_proposal VARCHAR(255) NOT NULL,
+                hash_final_report VARCHAR(40) NOT NULL,
+                allow_modifications_date DATETIME NOT NULL,
+                shift_id INTEGER DEFAULT NULL,
+                CONSTRAINT FK_C49C4FD9BB70BC0E FOREIGN KEY (shift_id) REFERENCES Shift (id)
+            )
+        ');
+
+        // Create Milestone table
+        $pdo->exec('
+            CREATE TABLE IF NOT EXISTS Milestone (
+                id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                year INTEGER NOT NULL,
+                name VARCHAR(255) NOT NULL,
+                description VARCHAR(255) NOT NULL,
+                page VARCHAR(255) NOT NULL,
+                individual BOOLEAN NOT NULL,
+                field1 VARCHAR(255) NOT NULL,
+                points1 INTEGER NOT NULL,
+                range1 INTEGER NOT NULL,
+                field2 VARCHAR(255) NOT NULL,
+                points2 INTEGER NOT NULL,
+                range2 INTEGER NOT NULL,
+                field3 VARCHAR(255) NOT NULL,
+                points3 INTEGER NOT NULL,
+                range3 INTEGER NOT NULL,
+                field4 VARCHAR(255) NOT NULL,
+                points4 INTEGER NOT NULL,
+                range4 INTEGER NOT NULL,
+                UNIQUE (year, name)
+            )
+        ');
+
+        // Create Grade table (composite primary key)
+        $pdo->exec('
+            CREATE TABLE IF NOT EXISTS Grade (
+                field1 INTEGER DEFAULT NULL,
+                field2 INTEGER DEFAULT NULL,
+                field3 INTEGER DEFAULT NULL,
+                field4 INTEGER DEFAULT NULL,
+                late_days INTEGER NOT NULL,
+                user_id VARCHAR(16) NOT NULL,
+                milestone_id INTEGER NOT NULL,
+                PRIMARY KEY (user_id, milestone_id),
+                CONSTRAINT FK_989B8130A76ED395 FOREIGN KEY (user_id) REFERENCES User (id),
+                CONSTRAINT FK_989B81304B3E2EDA FOREIGN KEY (milestone_id) REFERENCES Milestone (id)
+            )
+        ');
+
+        // Create Patch table
+        $pdo->exec('
+            CREATE TABLE IF NOT EXISTS Patch (
+                id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                status INTEGER NOT NULL,
+                type INTEGER NOT NULL,
+                hash VARCHAR(64) NOT NULL,
+                video_url VARCHAR(255) NOT NULL,
+                lines_added INTEGER NOT NULL,
+                lines_deleted INTEGER NOT NULL,
+                files_modified INTEGER NOT NULL,
+                group_id INTEGER NOT NULL,
+                platform VARCHAR(255) NOT NULL,
+                repo_branch VARCHAR(255) DEFAULT NULL,
+                src_branch VARCHAR(255) DEFAULT NULL,
+                pr_number INTEGER DEFAULT NULL,
+                CONSTRAINT FK_23EAB932FE54D947 FOREIGN KEY (group_id) REFERENCES ProjGroup (id)
+            )
+        ');
+
+        // Create PatchComment table
+        $pdo->exec('
+            CREATE TABLE IF NOT EXISTS PatchComment (
+                id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                text CLOB NOT NULL,
+                time DATETIME NOT NULL,
+                patch_id INTEGER NOT NULL,
+                user_id VARCHAR(16) DEFAULT NULL,
+                CONSTRAINT FK_89134298CD00882C FOREIGN KEY (patch_id) REFERENCES Patch (id),
+                CONSTRAINT FK_89134298A76ED395 FOREIGN KEY (user_id) REFERENCES User (id)
+            )
+        ');
+
+        // Create patch_user table
+        $pdo->exec('
+            CREATE TABLE IF NOT EXISTS patch_user (
+                patch_id INTEGER NOT NULL,
+                user_id VARCHAR(16) NOT NULL,
+                PRIMARY KEY (patch_id, user_id),
+                CONSTRAINT FK_3EAC6D63CD00882C FOREIGN KEY (patch_id) REFERENCES Patch (id),
+                CONSTRAINT FK_3EAC6D63A76ED395 FOREIGN KEY (user_id) REFERENCES User (id)
+            )
+        ');
+
+        // Create FinalGrade table
+        $pdo->exec('
+            CREATE TABLE IF NOT EXISTS FinalGrade (
+                year INTEGER NOT NULL,
+                formula VARCHAR(255) NOT NULL,
+                PRIMARY KEY (year)
+            )
+        ');
+
+        // Create Deadline table
+        $pdo->exec('
+            CREATE TABLE IF NOT EXISTS Deadline (
+                year INTEGER NOT NULL,
+                proj_proposal DATETIME NOT NULL,
+                bug_selection DATETIME NOT NULL,
+                feature_selection DATETIME NOT NULL,
+                patch_submission DATETIME NOT NULL,
+                final_report DATETIME NOT NULL,
+                PRIMARY KEY (year)
+            )
+        ');
+
+        // Create projgroup_user table (many-to-many)
+        $pdo->exec('
+            CREATE TABLE IF NOT EXISTS projgroup_user (
+                projgroup_id INTEGER NOT NULL,
+                user_id VARCHAR(16) NOT NULL,
+                PRIMARY KEY (projgroup_id, user_id),
+                CONSTRAINT FK_4E82DBC78B06FE40 FOREIGN KEY (projgroup_id) REFERENCES ProjGroup (id),
+                CONSTRAINT FK_4E82DBC7A76ED395 FOREIGN KEY (user_id) REFERENCES User (id)
+            )
+        ');
+
+        // Create PatchCIError table
+        $pdo->exec('
+            CREATE TABLE IF NOT EXISTS PatchCIError (
+                hash VARCHAR(64) NOT NULL,
+                name VARCHAR(255) NOT NULL,
+                url VARCHAR(512) NOT NULL,
+                time DATETIME NOT NULL,
+                patch_id INTEGER NOT NULL,
+                PRIMARY KEY (patch_id, hash, name),
+                CONSTRAINT FK_483CA63ECD00882C FOREIGN KEY (patch_id) REFERENCES Patch (id)
+            )
+        ');
+
+        // Create SelectedBug table
+        $pdo->exec('
+            CREATE TABLE IF NOT EXISTS SelectedBug (
+                year INTEGER NOT NULL,
+                issue_url VARCHAR(255) NOT NULL,
+                repro_url VARCHAR(255) NOT NULL,
+                description VARCHAR(4096) NOT NULL,
+                user_id VARCHAR(16) NOT NULL,
+                PRIMARY KEY (user_id, year),
+                UNIQUE (year, issue_url),
+                CONSTRAINT FK_A2B2B8B2A76ED395 FOREIGN KEY (user_id) REFERENCES User (id)
+            )
+        ');
+    }
+
+    protected function insertTestUser(string $userId, string $name, int $role = ROLE_STUDENT): void
+    {
+        $pdo = self::getPdo();
+        $pdo->prepare(
+            'INSERT INTO User (id, name, email, photo, role, repository_user, repository_etag, repository_last_processed_id)
+             VALUES (:id, :name, :email, :photo, :role, :repository_user, :repository_etag, :repository_last_processed_id)'
+        )->execute([
+            'id' => $userId,
+            'name' => $name,
+            'email' => $userId . '@test.example.com',
+            'photo' => '',
+            'role' => $role,
+            'repository_user' => '',
+            'repository_etag' => '',
+            'repository_last_processed_id' => '0',
+        ]);
+    }
+
+    protected function insertTestSession(string $sessionId, string $userId, ?\DateTimeImmutable $expires = null): void
+    {
+        if ($expires === null) {
+            $expires = new \DateTimeImmutable('+90 days');
+        }
+        
+        $pdo = self::getPdo();
+        $pdo->prepare(
+            'INSERT INTO Session (id, expires, user_id) VALUES (:id, :expires, :user_id)'
+        )->execute([
+            'id' => $sessionId,
+            'expires' => $expires->format('Y-m-d H:i:s'),
+            'user_id' => $userId,
+        ]);
+    }
+
+    protected function getSessionFromDatabase(string $sessionId): ?array
+    {
+        $pdo = self::getPdo();
+        $stmt = $pdo->prepare('SELECT * FROM Session WHERE id = ?');
+        $stmt->execute([$sessionId]);
+        $result = $stmt->fetch(\PDO::FETCH_ASSOC);
+        return $result ?: null;
+    }
+
+    protected function getUserFromDatabase(string $userId): ?array
+    {
+        $pdo = self::getPdo();
+        $stmt = $pdo->prepare('SELECT * FROM User WHERE id = ?');
+        $stmt->execute([$userId]);
+        $result = $stmt->fetch(\PDO::FETCH_ASSOC);
+        return $result ?: null;
+    }
+
+    protected function insertTestMilestone(int $year, string $milestone, string $description = ''): int
+    {
+        $pdo = self::getPdo();
+        $pdo->prepare(
+            'INSERT INTO Milestone (year, name, description, page, individual, field1, points1, range1, field2, points2, range2, field3, points3, range3, field4, points4, range4)
+             VALUES (:year, :name, :description, :page, 0, :f1, 100, 100, :f2, 100, 100, :f3, 100, 100, \'\', 0, 0)'
+        )->execute([
+            'year' => $year,
+            'name' => $milestone,
+            'description' => $description,
+            'page' => '',
+            'f1' => 'Code Quality',
+            'f2' => 'Functionality',
+            'f3' => 'Documentation',
+        ]);
+        
+        return (int)$pdo->lastInsertId();
+    }
+
+    protected function insertTestGrade(string $userId, int $milestoneId, int $field1, int $field2 = 0, int $field3 = 0, int $lateDays = 0): void
+    {
+        $pdo = self::getPdo();
+        $pdo->prepare(
+            'INSERT INTO Grade (field1, field2, field3, field4, late_days, user_id, milestone_id)
+             VALUES (:field1, :field2, :field3, NULL, :late_days, :user_id, :milestone_id)'
+        )->execute([
+            'field1' => $field1,
+            'field2' => $field2,
+            'field3' => $field3,
+            'late_days' => $lateDays,
+            'user_id' => $userId,
+            'milestone_id' => $milestoneId,
+        ]);
+    }
+
+    protected function getGradesFromDatabase(string $userId, int $milestoneId): ?array
+    {
+        $pdo = self::getPdo();
+        $stmt = $pdo->prepare('SELECT * FROM Grade WHERE user_id = ? AND milestone_id = ?');
+        $stmt->execute([$userId, $milestoneId]);
+        $result = $stmt->fetch(\PDO::FETCH_ASSOC);
+        return $result ?: null;
+    }
+
+    protected function insertTestShift(int $year, string $shiftName = 'Test Shift'): int
+    {
+        $pdo = self::getPdo();
+        $pdo->prepare(
+            'INSERT INTO Shift (name, year, prof_id)
+             VALUES (:name, :year, NULL)'
+        )->execute([
+            'name' => $shiftName,
+            'year' => $year,
+        ]);
+        
+        return (int)$pdo->lastInsertId();
+    }
+
+    protected function insertTestGroup(int $groupNumber, int $year, int $shiftId, string $projectName = ''): int
+    {
+        $pdo = self::getPdo();
+        $pdo->prepare(
+            'INSERT INTO ProjGroup (group_number, year, shift_id, project_name, project_description, project_website, repository, cla, dco, major_users, coding_style, bugs_for_beginners, project_ideas, student_programs, getting_started_manual, developers_manual, testing_manual, developers_mailing_list, patch_submission, hash_proposal_file, url_proposal, hash_final_report, allow_modifications_date)
+             VALUES (:group_number, :year, :shift_id, :project_name, :project_description, :project_website, :repository, 0, 0, :major_users, :coding_style, :bugs_for_beginners, :project_ideas, :student_programs, :getting_started_manual, :developers_manual, :testing_manual, :developers_mailing_list, :patch_submission, :hash_proposal_file, :url_proposal, :hash_final_report, :allow_modifications_date)'
+        )->execute([
+            'group_number' => $groupNumber,
+            'year' => $year,
+            'shift_id' => $shiftId,
+            'project_name' => $projectName,
+            'project_description' => '',
+            'project_website' => '',
+            'repository' => '',
+            'major_users' => '',
+            'coding_style' => '',
+            'bugs_for_beginners' => '',
+            'project_ideas' => '',
+            'student_programs' => '',
+            'getting_started_manual' => '',
+            'developers_manual' => '',
+            'testing_manual' => '',
+            'developers_mailing_list' => '',
+            'patch_submission' => '',
+            'hash_proposal_file' => '',
+            'url_proposal' => '',
+            'hash_final_report' => '',
+            'allow_modifications_date' => (new \DateTimeImmutable())->format('Y-m-d H:i:s'),
+        ]);
+        
+        return (int)$pdo->lastInsertId();
+    }
+
+    protected function insertGroupMembership(int $groupId, string $userId): void
+    {
+        $pdo = self::getPdo();
+        $pdo->prepare(
+            'INSERT INTO projgroup_user (projgroup_id, user_id) VALUES (:group_id, :user_id)'
+        )->execute([
+            'group_id' => $groupId,
+            'user_id' => $userId,
+        ]);
+    }
+
+    protected function getGroupFromDatabase(int $groupId): ?array
+    {
+        $pdo = self::getPdo();
+        $stmt = $pdo->prepare('SELECT * FROM ProjGroup WHERE id = ?');
+        $stmt->execute([$groupId]);
+        $result = $stmt->fetch(\PDO::FETCH_ASSOC);
+        return $result ?: null;
+    }
+
+    protected function getGroupMembersFromDatabase(int $groupId): array
+    {
+        $pdo = self::getPdo();
+        $stmt = $pdo->prepare('SELECT user_id FROM projgroup_user WHERE projgroup_id = ?');
+        $stmt->execute([$groupId]);
+        return $stmt->fetchAll(\PDO::FETCH_COLUMN, 0);
+    }
+}

--- a/tests/Integration/DiscoverProjectsIntegrationTest.php
+++ b/tests/Integration/DiscoverProjectsIntegrationTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Tests\Integration;
+
+use Tests\Unit\Base\UnitTestCase;
+use Tests\Mocks\MockGitHubClient;
+
+/**
+ * Integration test suite for DiscoverProjects
+ * 
+ * Tests the actual GitHub API integration for project discovery
+ */
+class DiscoverProjectsIntegrationTest extends UnitTestCase
+{
+    private mixed $oldGitHubClientCached = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->oldGitHubClientCached = $GLOBALS['github_client_cached'] ?? null;
+        $GLOBALS['github_client_cached'] = $this->mockGitHubClient();
+    }
+
+    protected function tearDown(): void
+    {
+        $GLOBALS['github_client_cached'] = $this->oldGitHubClientCached;
+        parent::tearDown();
+    }
+
+    /**
+     * Test searchByKeyword executes delegation to GitHub API
+     */
+    public function testSearchByKeywordExecutesDelegation()
+    {
+        $result = \DiscoverProjects::searchByKeyword('api', 'php', false);
+
+        $this->assertCount(1, $result);
+        $this->assertEquals('github:large/repo', $result[0]['name']);
+        $this->assertStringContainsString('api in:name,description,topics', $GLOBALS['github_client_cached']->queries[0]);
+    }
+
+    /**
+     * Test searchByKeyword with empty keywords
+     */
+    public function testSearchByKeywordWithEmptyKeywords()
+    {
+        $result = \DiscoverProjects::searchByKeyword('', 'php', false);
+
+        $this->assertCount(1, $result);
+        $this->assertStringContainsString('in:name,description,topics', $GLOBALS['github_client_cached']->queries[0]);
+    }
+
+    /**
+     * Test searchByKeyword with different languages
+     */
+    public function testSearchByKeywordDifferentLanguages()
+    {
+        $languages = ['php', 'javascript', 'python', 'java'];
+        foreach ($languages as $lang) {
+            $result = \DiscoverProjects::searchByKeyword('test', $lang, false);
+            $this->assertCount(1, $result);
+        }
+
+        $this->assertStringContainsString('language:php', $GLOBALS['github_client_cached']->queries[0]);
+        $this->assertStringContainsString('language:java', $GLOBALS['github_client_cached']->queries[3]);
+    }
+
+    /**
+     * Test searchByKeyword with newbie issues flag
+     */
+    public function testSearchByKeywordNewbieIssuesFlag()
+    {
+        $resultWithNewbie = \DiscoverProjects::searchByKeyword('help', 'php', true);
+        $resultWithoutNewbie = \DiscoverProjects::searchByKeyword('help', 'php', false);
+
+        $this->assertCount(1, $resultWithNewbie);
+        $this->assertCount(1, $resultWithoutNewbie);
+        $this->assertStringContainsString('good-first-issues:>30', $GLOBALS['github_client_cached']->queries[0]);
+        $this->assertStringNotContainsString('good-first-issues:>30', $GLOBALS['github_client_cached']->queries[1]);
+    }
+
+    private function mockGitHubClient(): MockGitHubClient
+    {
+        return new MockGitHubClient(
+            searchResults: ['items' => [[
+                'full_name' => 'large/repo',
+                'description' => 'Large mock repository',
+                'html_url' => 'https://github.com/large/repo',
+                'stargazers_count' => 1200,
+                'open_issues' => 42,
+                'language' => 'PHP',
+                'topics' => ['api'],
+                'pushed_at' => '2026-04-26T10:00:00+00:00',
+            ]]],
+            languagesByRepository: ['large/repo' => ['PHP' => 4_800_000]],
+            participationByRepository: ['large/repo' => [
+                'all' => array_merge(array_fill(0, 48, 0), [10, 10, 10, 10]),
+                'owner' => array_fill(0, 52, 0),
+            ]]
+        );
+    }
+}

--- a/tests/Integration/FactoryMethodIntegrationTest.php
+++ b/tests/Integration/FactoryMethodIntegrationTest.php
@@ -1,0 +1,486 @@
+<?php
+// Integration test for Patch::factory using the upgraded MockGitHubClient
+
+use PHPUnit\Framework\TestCase;
+use Tests\Mocks\FakeQueryResultEntityManager;
+use Tests\Mocks\MockGitHubClient;
+
+require_once __DIR__ . '/../../entities/Patch.php';
+require_once __DIR__ . '/../../entities/GitHub/GitHubPatch.php';
+require_once __DIR__ . '/../../entities/ProjGroup.php';
+require_once __DIR__ . '/../../entities/User.php';
+require_once __DIR__ . '/../../entities/Shift.php';
+require_once __DIR__ . '/../../entities/Repository.php';
+require_once __DIR__ . '/../Mocks/MockGitHubClient.php';
+
+class FactoryMethodIntegrationTest extends TestCase
+{
+    public function testPatchFactoryThrowsOnMergeCommitMessage()
+    {
+        [$group, $user, $url] = $this->patchFixture();
+        $this->mockCompare(commits: [
+            $this->commit(['message' => 'Merge branch feature']),
+        ]);
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('Merge commits are not allowed');
+        Patch::factory($group, $url, PatchType::Feature, 'desc', $user);
+    }
+
+    public function testPatchFactoryThrowsOnMissingDcoSignature()
+    {
+        [$group, $user, $url] = $this->patchFixture();
+        $group->dco = true;
+        $this->mockCompare(commits: [
+            $this->commit(['message' => 'A commit message without DCO']),
+        ]);
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('Missing signature in a project with DCO.');
+        Patch::factory($group, $url, PatchType::Feature, 'desc', $user);
+    }
+
+    public function testPatchFactoryThrowsOnInvalidCoAuthoredByLine()
+    {
+        [$group, $user, $url] = $this->patchFixture();
+        $this->mockCompare(commits: [
+            $this->commit([
+                'message' => "A commit\nCo-authored-by: someone <someone@example.com>\nnot at end",
+            ]),
+        ]);
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('Co-authored-by lines must be at the end');
+        Patch::factory($group, $url, PatchType::Feature, 'desc', $user);
+    }
+
+    public function testPatchFactoryThrowsOnShortCommitMessage()
+    {
+        [$group, $user, $url] = $this->patchFixture();
+        $this->mockCompare(commits: [
+            $this->commit(['message' => 'short']),
+        ]);
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('Commit message is too short');
+        Patch::factory($group, $url, PatchType::Feature, 'desc', $user);
+    }
+
+    public function testPatchFactoryThrowsOnTooManyShortLines()
+    {
+        [$group, $user, $url] = $this->patchFixture();
+        $this->mockCompare(commits: [
+            $this->commit([
+                'message' => "short\nshort\nshort\nshort\nshort\nshort\nshort\nshort\nshort\nshort\nlong enough line for limit",
+            ]),
+        ]);
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('Most lines of the commit message are too short');
+        Patch::factory($group, $url, PatchType::Feature, 'desc', $user);
+    }
+
+    private mixed $oldGitHubClient = null;
+    private mixed $oldGitHubClientCached = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // Save original globals before patching
+        global $github_client, $github_client_cached;
+        $this->oldGitHubClient = $github_client ?? null;
+        $this->oldGitHubClientCached = $github_client_cached ?? null;
+        // Set up the global mock client for all GitHub API calls
+        $github_client = new MockGitHubClient();
+        $github_client_cached = $github_client;
+    }
+
+    protected function tearDown(): void
+    {
+        // Restore original globals
+        global $github_client, $github_client_cached;
+        $github_client = $this->oldGitHubClient;
+        $github_client_cached = $this->oldGitHubClientCached;
+        parent::tearDown();
+    }
+
+    public function testPatchFactoryCreatesGitHubPatchSuccessfully()
+    {
+        [$group, $user, $url] = $this->patchFixture();
+        $description = 'This is a test patch.';
+        $this->mockCompare();
+
+        $patch = Patch::factory($group, $url, PatchType::Feature, $description, $user);
+
+        $this->assertInstanceOf(GitHub\GitHubPatch::class, $patch);
+        $this->assertEquals($group, $patch->group);
+        $this->assertEquals(PatchType::Feature, $patch->type);
+        $this->assertEquals('feature-branch', $patch->branch());
+        $this->assertEquals('mockorg:mockrepo:feature-branch', $patch->origin());
+        $this->assertEquals('Mock User', $patch->commits()[0]['name']);
+        $this->assertEquals('ist12345@tecnico.ulisboa.pt', $patch->commits()[0]['email']);
+        $this->assertEquals('mocksha123', $patch->commits()[0]['hash']);
+        $this->assertEquals(1, $patch->lines_added);
+        $this->assertEquals(1, $patch->lines_deleted);
+        $this->assertEquals(1, $patch->files_modified);
+        $this->assertTrue($patch->isValid());
+    }
+
+    public function testPatchFactoryThrowsWhenNoRepository()
+    {
+        [$group, $user, $url] = $this->patchFixture(repository: '');
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('Group has no repository yet');
+        Patch::factory($group, $url, PatchType::Feature, 'desc', $user);
+    }
+
+    public function testPatchFactoryThrowsOnEmptyDescription()
+    {
+        [$group, $user, $url] = $this->patchFixture();
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('Empty description');
+        Patch::factory($group, $url, PatchType::Feature, '', $user);
+    }
+
+    public function testPatchFactoryThrowsOnNoRecognizedAuthors()
+    {
+        [$group, $user, $url] = $this->patchFixture();
+        $group->resetStudents();
+        $this->mockCompare(commits: [
+            $this->commit(['message' => 'A valid commit message with no coauthors.']),
+        ]);
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage("Name doesn't match any of the group's student names: Mock User");
+        Patch::factory($group, $url, PatchType::Feature, 'desc', $user);
+    }
+
+    public function testPatchFactoryThrowsOnForbiddenBranchName()
+    {
+        [$group, $user, $url] = $this->patchFixture(
+            url: 'https://github.com/mockorg/mockrepo/compare/main...mockorg:mockrepo:main'
+        );
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('Invalid branch name: main');
+        Patch::factory($group, $url, PatchType::Feature, 'desc', $user);
+    }
+
+    public function testPatchFactoryThrowsOnDuplicatePatch()
+    {
+        [$group, $user, $url] = $this->patchFixture();
+        $this->mockCompare();
+
+        $patch1 = Patch::factory($group, $url, PatchType::Feature, 'desc', $user);
+        $group->patches->add($patch1);
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('Duplicated patch');
+        Patch::factory($group, $url, PatchType::Feature, 'desc', $user);
+    }
+
+    public function testPatchFactoryThrowsOnTrailingWhitespaceInDiff()
+    {
+        [$group, $user, $url] = $this->patchFixture();
+        $this->mockCompare(files: [[
+            'filename' => 'file1.php',
+            'patch' => "+Added line   \n",
+            'additions' => 1,
+            'deletions' => 0,
+        ]]);
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('has trailing whitespace');
+        Patch::factory($group, $url, PatchType::Feature, 'desc', $user);
+    }
+
+    public function testPatchFactoryThrowsOnMissingNewlineInDiff()
+    {
+        [$group, $user, $url] = $this->patchFixture();
+        $this->mockCompare(files: [[
+            'filename' => 'file1.php',
+            'patch' => "+Added line\n\\ No newline at end of file",
+            'additions' => 1,
+            'deletions' => 0,
+        ]]);
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('is missing a newline at the end');
+        Patch::factory($group, $url, PatchType::Feature, 'desc', $user);
+    }
+
+    public function testPatchFactoryThrowsOnInvalidCommitEmail()
+    {
+        [$group, $user, $url] = $this->patchFixture();
+        $this->mockCompare(commits: [
+            $this->commit(['email' => 'mockuser@example.com']),
+        ]);
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('Invalid email used in commit');
+        Patch::factory($group, $url, PatchType::Feature, 'desc', $user);
+    }
+
+    public function testPatchFactoryThrowsOnMalformedCoAuthoredByLine()
+    {
+        [$group, $user, $url] = $this->patchFixture();
+        $this->mockCompare(commits: [
+            $this->commit([
+                'message' => 'A valid commit message with malformed coauthor marker.' .
+                             "\nCo-authored by: Someone <someone@example.com>",
+            ]),
+        ]);
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('Invalid Co-authored-by line');
+        Patch::factory($group, $url, PatchType::Feature, 'desc', $user);
+    }
+
+    public function testPatchFactoryCanIgnoreValidationErrors()
+    {
+        [$group, $user, $url] = $this->patchFixture();
+        $this->mockCompare(files: [[
+            'filename' => 'file1.php',
+            'patch' => "+Added line   \n",
+            'additions' => 1,
+            'deletions' => 0,
+        ]]);
+
+        $patch = Patch::factory($group, $url, PatchType::Feature, 'desc', $user, '', true);
+
+        $this->assertStringContainsString('Failed validation:', $patch->comments->last()->text);
+        $this->assertStringContainsString('has trailing whitespace', $patch->comments->last()->text);
+    }
+
+    public function testPatchFactoryThrowsWhenFeatureIssueIsNotReferenced()
+    {
+        [$group, $user, $url] = $this->patchFixture(
+            proposal: 'https://github.com/mockorg/mockrepo/issues/42'
+        );
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('No commit message references the issue #id');
+        Patch::factory($group, $url, PatchType::Feature, 'desc', $user);
+    }
+
+    public function testPatchFactoryAllowsFeatureIssueWhenReferenced()
+    {
+        [$group, $user, $url] = $this->patchFixture(
+            proposal: 'https://github.com/mockorg/mockrepo/issues/42'
+        );
+        $this->mockCompare(commits: [
+            $this->commit([
+                'message' => 'Implement feature requested in issue #42 with enough detail.',
+            ]),
+        ]);
+
+        $patch = Patch::factory($group, $url, PatchType::Feature, 'desc', $user);
+
+        $this->assertInstanceOf(GitHub\GitHubPatch::class, $patch);
+    }
+
+    public function testPatchFactoryThrowsWhenProjectDisallowsIssueRefs()
+    {
+        [$group, $user, $url] = $this->patchFixture(
+            repository: 'github:godotengine/godot',
+            url: 'https://github.com/godotengine/godot/compare/main...godotengine:godot:feature-branch'
+        );
+        $this->mockCompare(commits: [
+            $this->commit([
+                'message' => 'Fixes #42 with enough detail to pass validation.',
+            ]),
+        ]);
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage("Commit message references an issue, but it shouldn't");
+        Patch::factory($group, $url, PatchType::Feature, 'desc', $user);
+    }
+
+    public function testPatchFactoryThrowsWhenBugFixHasMultipleCommits()
+    {
+        [$group, $user, $url] = $this->patchFixture();
+        $oldEntityManager = $this->mockSelectedBug('https://github.com/mockorg/mockrepo/issues/42');
+        $this->mockCompare(commits: [
+            $this->commit(['message' => 'Fixes #42 with enough detail for first commit.']),
+            $this->commit(['sha' => 'mocksha456', 'message' => 'Fixes #42 with enough detail for second commit.']),
+        ]);
+
+        try {
+            $this->expectException(ValidationException::class);
+            $this->expectExceptionMessage('Only 1 commit allowed');
+            Patch::factory($group, $url, PatchType::BugFix, 'desc', $user);
+        } finally {
+            $GLOBALS['entityManager'] = $oldEntityManager;
+        }
+    }
+
+    public function testPatchFactoryThrowsWhenBugFixHasNoSelectedBug()
+    {
+        [$group, $user, $url] = $this->patchFixture();
+        $oldEntityManager = $this->mockSelectedBug(null);
+
+        try {
+            $this->expectException(ValidationException::class);
+            $this->expectExceptionMessage('Patch does not have a bug associated');
+            Patch::factory($group, $url, PatchType::BugFix, 'desc', $user);
+        } finally {
+            $GLOBALS['entityManager'] = $oldEntityManager;
+        }
+    }
+
+    public function testPatchFactoryThrowsWhenBugFixDoesNotReferenceIssue()
+    {
+        [$group, $user, $url] = $this->patchFixture();
+        $oldEntityManager = $this->mockSelectedBug('https://github.com/mockorg/mockrepo/issues/42');
+
+        try {
+            $this->expectException(ValidationException::class);
+            $this->expectExceptionMessage("Commit message doesn't reference the fixed issue properly");
+            Patch::factory($group, $url, PatchType::BugFix, 'desc', $user);
+        } finally {
+            $GLOBALS['entityManager'] = $oldEntityManager;
+        }
+    }
+
+    public function testPatchFactoryThrowsWhenBugFixReferencesWrongIssue()
+    {
+        [$group, $user, $url] = $this->patchFixture();
+        $oldEntityManager = $this->mockSelectedBug('https://github.com/mockorg/mockrepo/issues/42');
+        $this->mockCompare(commits: [
+            $this->commit([
+                'message' => 'Fixes #99 with enough detail to pass message validation.',
+            ]),
+        ]);
+
+        try {
+            $this->expectException(ValidationException::class);
+            $this->expectExceptionMessage("Referenced issue #99 doesn't match");
+            Patch::factory($group, $url, PatchType::BugFix, 'desc', $user);
+        } finally {
+            $GLOBALS['entityManager'] = $oldEntityManager;
+        }
+    }
+
+    public function testPatchFactoryCreatesBugFixWhenIssueIsReferenced()
+    {
+        [$group, $user, $url] = $this->patchFixture();
+        $oldEntityManager = $this->mockSelectedBug('https://github.com/mockorg/mockrepo/issues/42');
+        $this->mockCompare(commits: [
+            $this->commit([
+                'message' => 'Fixes #42 with enough detail to pass message validation.',
+            ]),
+        ]);
+
+        try {
+            $patch = Patch::factory($group, $url, PatchType::BugFix, 'desc', $user);
+            $this->assertEquals(PatchType::BugFix, $patch->type);
+        } finally {
+            $GLOBALS['entityManager'] = $oldEntityManager;
+        }
+    }
+
+    private function patchFixture(
+        string $repository = 'github:mockorg/mockrepo',
+        string $url = 'https://github.com/mockorg/mockrepo/compare/main...mockorg:mockrepo:feature-branch',
+        string $proposal = ''
+    ): array {
+        $shift = new Shift('T01', 2026);
+        $group = new ProjGroup(1, 2026, $shift);
+        $group->repository = $repository;
+        $group->url_proposal = $proposal;
+
+        $user = new User('mockuser', 'Mock User', 'ist12345@tecnico.ulisboa.pt', '', 1, false);
+        $group->addStudent($user);
+
+        return [$group, $user, $url];
+    }
+
+    private function commit(array $overrides = []): array
+    {
+        $defaults = [
+            'sha' => 'mocksha123',
+            'login' => 'mockuser',
+            'name' => 'Mock User',
+            'email' => 'ist12345@tecnico.ulisboa.pt',
+            'message' => 'Mock commit message with enough detail for testing.',
+        ];
+        $data = array_merge($defaults, $overrides);
+
+        return [
+            'sha' => $data['sha'],
+            'author' => ['login' => $data['login']],
+            'commit' => [
+                'author' => ['name' => $data['name'], 'email' => $data['email']],
+                'message' => $data['message'],
+            ],
+        ];
+    }
+
+    private function mockCompare(?array $commits = null, ?array $files = null): void
+    {
+        $commits ??= [$this->commit()];
+        $files ??= [[
+            'filename' => 'file1.php',
+            'patch' => "+Added line\n-Removed line\n",
+            'additions' => 1,
+            'deletions' => 1,
+        ]];
+
+        global $github_client, $github_client_cached;
+        $github_client = new class($commits, $files) extends \Tests\Mocks\MockGitHubClient {
+            public function __construct(private array $commits, private array $files) {}
+
+            public function api($endpoint) {
+                if ($endpoint === 'issue') {
+                    return new class {
+                        public function show($owner, $repo, $number) {
+                            return [
+                                'title' => "Mock Issue #$number",
+                                'body' => 'Mock issue body for patch review context.',
+                            ];
+                        }
+                    };
+                }
+                if ($endpoint === 'repo') {
+                    return new class($this->commits, $this->files) {
+                        public function __construct(private array $commits, private array $files) {}
+
+                        public function commits() {
+                            return new class($this->commits, $this->files) {
+                                public function __construct(private array $commits, private array $files) {}
+
+                                public function compare($org, $repo, $srcBranch, $repoBranch, $accept = null) {
+                                    if ($accept === 'application/vnd.github.patch') {
+                                        return "diff --git a/file1.php b/file1.php\n+Added line\n-Removed line\n";
+                                    }
+                                    return [
+                                        'commits' => $this->commits,
+                                        'files' => $this->files,
+                                    ];
+                                }
+                            };
+                        }
+                    };
+                }
+                return parent::api($endpoint);
+            }
+        };
+        $github_client_cached = $github_client;
+    }
+
+    private function mockSelectedBug(?string $issueUrl): mixed
+    {
+        $oldEntityManager = $GLOBALS['entityManager'] ?? null;
+        $bug = null;
+        if ($issueUrl !== null) {
+            $bug = new SelectedBug();
+            $bug->issue_url = $issueUrl;
+        }
+
+        $GLOBALS['entityManager'] = new FakeQueryResultEntityManager($bug);
+
+        return $oldEntityManager;
+    }
+}

--- a/tests/Integration/GitHubDiscoverProjectsIntegrationTest.php
+++ b/tests/Integration/GitHubDiscoverProjectsIntegrationTest.php
@@ -1,0 +1,180 @@
+<?php
+
+namespace Tests\Integration;
+
+use Tests\Unit\Base\UnitTestCase;
+use Tests\Mocks\MockGitHubClient;
+
+/**
+ * Integration tests for GitHub Project Discovery
+ * 
+ * These tests validate the interaction between:
+ * - GitHub API client
+ * - Repository discovery logic
+ * - Data transformation and storage
+ * 
+ * Note: These require configured GitHub API client to run
+ */
+class GitHubDiscoverProjectsIntegrationTest extends UnitTestCase
+{
+    private mixed $oldGitHubClientCached = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->oldGitHubClientCached = $GLOBALS['github_client_cached'] ?? null;
+        $GLOBALS['github_client_cached'] = $this->mockGitHubClient();
+    }
+
+    protected function tearDown(): void
+    {
+        $GLOBALS['github_client_cached'] = $this->oldGitHubClientCached;
+        parent::tearDown();
+    }
+
+    /**
+     * Test full discovery workflow with keyword search
+     * 
+     * Workflow:
+     * 1. Search repository by keyword
+     * 2. Apply language filter
+     * 3. Filter by issue availability
+     * 4. Return formatted results
+     */
+    public function testKeywordSearchDiscoveryWorkflow()
+    {
+        $results = \GitHub\GitHubDiscoverProjects::searchByKeyword('api', 'PHP', true);
+
+        $this->assertCount(1, $results);
+        $this->assertEquals('github:large/repo', $results[0]['name']);
+        $this->assertEquals('PHP', $results[0]['language']);
+        $this->assertStringContainsString('in:name,description,topics', $GLOBALS['github_client_cached']->queries[0]);
+        $this->assertStringContainsString('language:PHP', $GLOBALS['github_client_cached']->queries[0]);
+        $this->assertStringContainsString('good-first-issues:>30', $GLOBALS['github_client_cached']->queries[0]);
+    }
+
+    /**
+     * Test discovery with topic-based search
+     * 
+     * Workflow:
+     * 1. Search repositories by topics
+     * 2. Filter by project maturity (size, stars)
+     * 3. Validate project requirements
+     */
+    public function testTopicBasedDiscoveryWorkflow()
+    {
+        $results = \GitHub\GitHubDiscoverProjects::searchByTopics('framework', '', false);
+
+        $this->assertCount(1, $results);
+        $this->assertStringContainsString('in:topics', $GLOBALS['github_client_cached']->queries[0]);
+        $this->assertStringNotContainsString('language:', $GLOBALS['github_client_cached']->queries[0]);
+    }
+
+    /**
+     * Test data transformation and persistence
+     * 
+     * Workflow:
+     * 1. Fetch raw GitHub API response
+     * 2. Transform to standard format
+     * 3. Calculate derived metrics (LOC, activity)
+     * 4. Store or cache results
+     */
+    public function testDataTransformationAndPersistence()
+    {
+        $results = \GitHub\GitHubDiscoverProjects::searchByKeyword('api', null, false);
+
+        $this->assertEquals('Large mock repository', $results[0]['description']);
+        $this->assertEquals('https://github.com/large/repo', $results[0]['url']);
+        $this->assertEquals('1' . "\u{202F}" . 'k', $results[0]['stars']);
+        $this->assertEquals('120' . "\u{202F}" . 'k', $results[0]['loc']);
+        $this->assertEquals(42, $results[0]['open_issues']);
+        $this->assertEquals(['api', 'framework'], $results[0]['topics']);
+        $this->assertInstanceOf(\DateTimeImmutable::class, $results[0]['last_push']);
+    }
+
+    /**
+     * Test filter combination effects
+     * 
+     * Workflow:
+     * 1. Apply language filter
+     * 2. Apply maturity filter (stars >= 200)
+     * 3. Apply size filter (LOC >= 100k)
+     * 4. Apply newbie-friendliness filter
+     * 5. Validate results meet all criteria
+     */
+    public function testMultipleFilterInteraction()
+    {
+        \GitHub\GitHubDiscoverProjects::searchByKeyword('help', 'JavaScript', true);
+
+        $query = $GLOBALS['github_client_cached']->queries[0];
+        $this->assertStringContainsString('size:>3900', $query);
+        $this->assertStringContainsString('stars:>=200', $query);
+        $this->assertStringContainsString('pushed:', $query);
+        $this->assertStringContainsString('language:JavaScript', $query);
+        $this->assertStringContainsString('good-first-issues:>30', $query);
+        $this->assertStringContainsString('mirror:false archived:false template:false', $query);
+    }
+
+    /**
+     * Integration test with mock GitHub API client
+     * 
+     * Tests the discovery workflow using a mock client that simulates
+     * GitHub API responses. This validates data transformation and
+     * project filtering logic without requiring network access.
+     * 
+     * Workflow:
+     * 1. Initialize mocked GitHub API client
+     * 2. Execute search request
+     * 3. Parse mock API response
+     * 4. Calculate line of code metrics
+     * 5. Return formatted project list
+     */
+    public function testMockBackedIntegration()
+    {
+        $results = \GitHub\GitHubDiscoverProjects::searchByKeyword('api', 'PHP', false);
+
+        $this->assertCount(1, $results);
+        $this->assertSame(['api', 'framework'], $results[0]['topics']);
+    }
+
+    private function mockGitHubClient(): MockGitHubClient
+    {
+        $activity = [
+            'all' => array_merge(array_fill(0, 48, 0), [10, 10, 10, 10]),
+            'owner' => array_fill(0, 52, 0),
+        ];
+
+        return new MockGitHubClient(
+            searchResults: ['items' => [
+                [
+                    'full_name' => 'large/repo',
+                    'description' => 'Large mock repository',
+                    'html_url' => 'https://github.com/large/repo',
+                    'stargazers_count' => 1200,
+                    'open_issues' => 42,
+                    'language' => 'PHP',
+                    'topics' => ['api', 'framework'],
+                    'pushed_at' => '2026-04-26T10:00:00+00:00',
+                ],
+                [
+                    'full_name' => 'small/repo',
+                    'description' => 'Small mock repository',
+                    'html_url' => 'https://github.com/small/repo',
+                    'stargazers_count' => 300,
+                    'open_issues' => 5,
+                    'language' => 'PHP',
+                    'topics' => ['api'],
+                    'pushed_at' => '2026-04-26T10:00:00+00:00',
+                ],
+            ]],
+            languagesByRepository: [
+                'large/repo' => ['PHP' => 4_800_000],
+                'small/repo' => ['PHP' => 40_000],
+            ],
+            participationByRepository: [
+                'large/repo' => $activity,
+                'small/repo' => $activity,
+            ]
+        );
+    }
+}

--- a/tests/Integration/GradingIntegrationTest.php
+++ b/tests/Integration/GradingIntegrationTest.php
@@ -1,0 +1,320 @@
+<?php
+
+namespace Tests\Integration;
+
+use Tests\Integration\Base\IntegrationTestCase;
+
+/**
+ * Integration tests for Grading workflows
+ * 
+ * Tests the interaction between:
+ * - User (student)
+ * - Milestone (assignment)
+ * - Grade (score)
+ * - Grade calculation and validation
+ */
+class GradingIntegrationTest extends IntegrationTestCase
+{
+    private \User $student;
+    private \Milestone $milestone;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Create test student
+        $this->student = new \User(
+            username: 'student1',
+            name: 'John Student',
+            email: 'john@example.com',
+            photo: '',
+            role: ROLE_STUDENT,
+            dummy: false
+        );
+
+        // Create test milestone with multiple grading fields
+        $this->milestone = new \Milestone(2024, 'Assignment 1');
+        $this->milestone->description = 'First programming assignment';
+        $this->milestone->individual = false;
+        $this->milestone->field1 = 'Code Quality';
+        $this->milestone->points1 = 40;
+        $this->milestone->range1 = 100;
+        $this->milestone->field2 = 'Functionality';
+        $this->milestone->points2 = 35;
+        $this->milestone->range2 = 100;
+        $this->milestone->field3 = 'Documentation';
+        $this->milestone->points3 = 15;
+        $this->milestone->range3 = 100;
+        $this->milestone->field4 = '';
+        $this->milestone->points4 = 0;
+        $this->milestone->range4 = 0;
+    }
+
+    /**
+     * Test student receives grade for milestone
+     * 
+     * Workflow:
+     * 1. Create grade for student + milestone
+     * 2. Set grade values for each field
+     * 3. Verify grade is properly linked
+     */
+    public function testStudentReceivesGradeForMilestone()
+    {
+        $grade = new \Grade();
+        $grade->user = $this->student;
+        $grade->milestone = $this->milestone;
+        $grade->field1 = 85;  // Code Quality
+        $grade->field2 = 90;  // Functionality
+        $grade->field3 = 88;  // Documentation
+        $grade->late_days = 0;
+
+        // Verify grade is linked to student and milestone
+        $this->assertEquals($this->student->id, $grade->user->id);
+        $this->assertEquals($this->milestone->name, $grade->milestone->name);
+        $this->assertEquals(85, $grade->field1);
+        $this->assertEquals(90, $grade->field2);
+        $this->assertEquals(88, $grade->field3);
+    }
+
+    /**
+     * Test grade calculation across multiple fields
+     * 
+     * Workflow:
+     * 1. Create grade with scores for each field
+     * 2. Calculate total points earned
+     * 3. Calculate total possible points
+     * 4. Calculate percentage
+     */
+    public function testGradeCalculationAcrossFields()
+    {
+        $grade = new \Grade();
+        $grade->user = $this->student;
+        $grade->milestone = $this->milestone;
+        $grade->field1 = 80;  // 80/100
+        $grade->field2 = 85;  // 85/100
+        $grade->field3 = 90;  // 90/100
+
+        // Calculate weighted score
+        $field1_points = (80 / 100) * 40;  // 32 points
+        $field2_points = (85 / 100) * 35;  // 29.75 points
+        $field3_points = (90 / 100) * 15;  // 13.5 points
+        $total = $field1_points + $field2_points + $field3_points;
+
+        $this->assertGreaterThan(70, $total);
+        $this->assertLessThan(91, $total);
+    }
+
+    /**
+     * Test late submission with late days penalty
+     * 
+     * Workflow:
+     * 1. Create grade with late days
+     * 2. Verify late_days is recorded
+     * 3. Calculate penalty if applicable
+     */
+    public function testLateSubmissionPenalty()
+    {
+        $grade = new \Grade();
+        $grade->user = $this->student;
+        $grade->milestone = $this->milestone;
+        $grade->field1 = 80;
+        $grade->field2 = 85;
+        $grade->field3 = 90;
+        $grade->late_days = 3;
+
+        // Verify late days are recorded
+        $this->assertEquals(3, $grade->late_days);
+        $this->assertGreaterThan(0, $grade->late_days);
+    }
+
+    /**
+     * Test multiple students graded on same milestone
+     * 
+     * Workflow:
+     * 1. Create grades for multiple students on same milestone
+     * 2. Verify each grade is independent
+     * 3. Verify different scores per student
+     */
+    public function testMultipleStudentsGraded()
+    {
+        $student1 = new \User('user1', 'Student 1', 'user1@example.com', '', ROLE_STUDENT, false);
+        $student2 = new \User('user2', 'Student 2', 'user2@example.com', '', ROLE_STUDENT, false);
+        $student3 = new \User('user3', 'Student 3', 'user3@example.com', '', ROLE_STUDENT, false);
+
+        $grade1 = new \Grade();
+        $grade1->user = $student1;
+        $grade1->milestone = $this->milestone;
+        $grade1->field1 = 85;
+        $grade1->field2 = 80;
+        $grade1->field3 = 75;
+
+        $grade2 = new \Grade();
+        $grade2->user = $student2;
+        $grade2->milestone = $this->milestone;
+        $grade2->field1 = 95;
+        $grade2->field2 = 92;
+        $grade2->field3 = 90;
+
+        $grade3 = new \Grade();
+        $grade3->user = $student3;
+        $grade3->milestone = $this->milestone;
+        $grade3->field1 = 70;
+        $grade3->field2 = 75;
+        $grade3->field3 = 80;
+
+        // Verify each student has different grades
+        $this->assertEquals(85, $grade1->field1);
+        $this->assertEquals(95, $grade2->field1);
+        $this->assertEquals(70, $grade3->field1);
+    }
+
+    /**
+     * Test partial grading (some fields not graded)
+     * 
+     * Workflow:
+     * 1. Create milestone with 4 grading fields
+     * 2. Grade only 2 fields
+     * 3. Leave other fields ungraded (null)
+     */
+    public function testPartialGrading()
+    {
+        $milestone = new \Milestone(2024, 'Partial Grade Test');
+        $milestone->field1 = 'Part A';
+        $milestone->range1 = 100;
+        $milestone->field2 = 'Part B';
+        $milestone->range2 = 100;
+        $milestone->field3 = '';  // Not graded
+        $milestone->field4 = '';  // Not graded
+
+        $grade = new \Grade();
+        $grade->user = $this->student;
+        $grade->milestone = $milestone;
+        $grade->field1 = 85;
+        $grade->field2 = 90;
+        $grade->field3 = null;  // Not graded
+        $grade->field4 = null;  // Not graded
+
+        $this->assertEquals(85, $grade->field1);
+        $this->assertEquals(90, $grade->field2);
+        $this->assertNull($grade->field3);
+        $this->assertNull($grade->field4);
+    }
+
+    /**
+     * Test student retrieves their own grades
+     * 
+     * Workflow:
+     * 1. Student has grades for multiple milestones
+     * 2. Student retrieves all their grades
+     * 3. Can filter by milestone or year
+     */
+    /**
+     * Test student retrieves own grades from database
+     * 
+     * Workflow:
+     * 1. Create student in database
+     * 2. Create milestone in database
+     * 3. Create grade for student in database
+     * 4. Query grades by student ID
+     * 5. Verify retrieved grade matches persisted data
+     */
+    public function testStudentRetrievesOwnGrades()
+    {
+        // Create student in database
+        $studentId = 'test_grades_' . bin2hex(random_bytes(4));
+        $this->insertTestUser($studentId, 'Grades Retrieval Student');
+        
+        // Create milestone in database
+        $milestoneId = $this->insertTestMilestone(2024, 'Assignment 1', 'First programming assignment');
+        
+        // Create grade for student
+        $this->insertTestGrade($studentId, $milestoneId, 85, 90, 88);
+        
+        // Query grades back from database
+        $retrievedGrade = $this->getGradesFromDatabase($studentId, $milestoneId);
+        
+        // Verify grade exists in database
+        $this->assertNotNull($retrievedGrade);
+        
+        // Verify grade belongs to correct student
+        $this->assertEquals($studentId, $retrievedGrade['user_id']);
+        
+        // Verify grade values persisted
+        $this->assertEquals(85, $retrievedGrade['field1']);
+        $this->assertEquals(90, $retrievedGrade['field2']);
+        $this->assertEquals(88, $retrievedGrade['field3']);
+        
+        // Verify milestone ID matches
+        $this->assertEquals($milestoneId, $retrievedGrade['milestone_id']);
+    }
+
+    /**
+     * Test final grade calculation from all milestones
+     * 
+     * Workflow:
+     * 1. Create student user in database
+     * 2. Create multiple milestones in database
+     * 3. Create grades for each milestone
+     * 4. Retrieve grades from database
+     * 5. Verify grades are persisted correctly
+     */
+    public function testFinalGradeCalculation()
+    {
+        // Create student in database
+        $studentId = 'test_finalgrade_' . bin2hex(random_bytes(4));
+        $this->insertTestUser($studentId, 'Grade Test Student');
+        
+        // Create multiple milestones in database
+        $m1Id = $this->insertTestMilestone(2024, 'M1', 'First Milestone');
+        $m2Id = $this->insertTestMilestone(2024, 'M2', 'Second Milestone');
+        
+        // Create grades for both milestones
+        $this->insertTestGrade($studentId, $m1Id, 85, 80, 90);
+        $this->insertTestGrade($studentId, $m2Id, 90, 95, 88);
+        
+        // Retrieve grades from database
+        $grade1 = $this->getGradesFromDatabase($studentId, $m1Id);
+        $grade2 = $this->getGradesFromDatabase($studentId, $m2Id);
+        
+        // Verify grades exist in database
+        $this->assertNotNull($grade1, 'Grade 1 should exist in database');
+        $this->assertNotNull($grade2, 'Grade 2 should exist in database');
+        
+        // Verify grade values match
+        $this->assertEquals(85, $grade1['field1']);
+        $this->assertEquals(80, $grade1['field2']);
+        $this->assertEquals(90, $grade1['field3']);
+        
+        $this->assertEquals(90, $grade2['field1']);
+        $this->assertEquals(95, $grade2['field2']);
+        $this->assertEquals(88, $grade2['field3']);
+        
+        // Verify we can calculate average from persisted grades
+        $average = ((85 + 80 + 90) / 3 + (90 + 95 + 88) / 3) / 2;
+        $this->assertGreaterThan(87, $average);
+        $this->assertLessThan(89, $average);
+    }
+
+    /**
+     * Test grade entry validation
+     * 
+     * Workflow:
+     * 1. Attempt to enter grade outside valid range
+     * 2. Validation catches error
+     * 3. Grade is not accepted
+     */
+    public function testGradeEntryValidation()
+    {
+        $grade = new \Grade();
+        $grade->user = $this->student;
+        $grade->milestone = $this->milestone;
+        $grade->field1 = 101;
+        $grade->field2 = 90;
+        $grade->field3 = 80;
+        $grade->field4 = null;
+
+        $this->expectException(\ValidationException::class);
+        $this->expectExceptionMessage('Field 1 exceeds allowed range');
+        $grade->validateFields();
+    }
+}

--- a/tests/Integration/Pages/BugsPageTest.php
+++ b/tests/Integration/Pages/BugsPageTest.php
@@ -1,0 +1,226 @@
+<?php
+
+namespace Tests\Integration\Pages;
+
+
+
+
+class BugsPageTest extends PageTestCase
+{
+    public function testBugsPageBuildsStudentFormWithExistingBugAndTable()
+    {
+        $year = get_current_year();
+        $student = $this->createPageUser('ist9601', 'Alice Student', ROLE_STUDENT);
+        $group = $this->createGroup(1001, $year, [$student]);
+        $group->repository = 'github:owner/repo';
+        $group->allow_modifications_date = new \DateTimeImmutable('-1 day');
+
+        $deadline = new \Deadline($year);
+        $deadline->bug_selection = new \DateTimeImmutable('+1 day');
+
+        $bug = new \SelectedBug();
+        $bug->user = $student;
+        $bug->year = $year;
+        $bug->issue_url = 'https://example.org/issues/42';
+        $bug->repro_url = '';
+        $bug->description = 'Steps to reproduce the bug.';
+
+        $oldEntityManager = $this->mockBugsEntityManager(
+            deadline: $deadline,
+            bugsByUser: [$student->id => $bug],
+            bugsByIssue: [$bug->issue_url => $bug]
+        );
+
+        try {
+            $this->setUpPageRuntime('bugs', $student);
+            $this->runPage('bugs');
+
+            $this->assertSame(
+                'You can submit this form multiple times until the deadline. Only the last submission will be considered.',
+                $GLOBALS['info_message']
+            );
+            $this->assertNotNull($GLOBALS['form']);
+            $this->assertTrue($GLOBALS['form']->has('issue_url'));
+            $this->assertTrue($GLOBALS['form']->has('repro_url'));
+            $this->assertTrue($GLOBALS['form']->has('description'));
+            $this->assertSame('https://example.org/issues/42', $GLOBALS['form']->get('issue_url')->getData());
+            $this->assertSame('', $GLOBALS['form']->get('repro_url')->getData());
+            $this->assertSame('Steps to reproduce the bug.', $GLOBALS['form']->get('description')->getData());
+
+            $this->assertCount(1, $GLOBALS['table']);
+            $row = $GLOBALS['table'][0];
+            $this->assertSame('Alice Student', $row['Student']);
+            $this->assertSame('link', $row['Issue']['label']);
+            $this->assertSame('https://example.org/issues/42', $row['Issue']['url']);
+            $this->assertSame(['longdata' => 'Steps to reproduce the bug.'], $row['Description']);
+            $this->assertSame('', $row['Video']);
+            $this->assertTrue($row['_large_table']);
+
+            $this->assertCount(1, $GLOBALS['__page_test_eval_boxes']);
+            $this->assertSame($group, $GLOBALS['__page_test_eval_boxes'][0]['group']);
+        } finally {
+            $GLOBALS['entityManager'] = $oldEntityManager;
+        }
+    }
+
+    public function testBugsPageCreatesNewBugAndPersistsIt()
+    {
+        $year = get_current_year();
+        $student = $this->createPageUser('ist9602', 'Bob Student', ROLE_STUDENT);
+        $group = $this->createGroup(1002, $year, [$student]);
+
+        $deadline = new \Deadline($year);
+        $deadline->bug_selection = new \DateTimeImmutable('+1 day');
+
+        $oldEntityManager = $this->mockBugsEntityManager(
+            deadline: $deadline,
+            bugsByUser: [],
+            bugsByIssue: []
+        );
+
+        try {
+            $this->setUpPageRuntime(
+                'bugs',
+                $student,
+                'POST',
+                [],
+                [
+                    'form' => [
+                        'issue_url' => 'https://example.org/issues/99',
+                        'repro_url' => '',
+                        'description' => 'New bug description',
+                        'submit' => '',
+                    ],
+                ]
+            );
+            $this->runPage('bugs');
+
+            $saved = $GLOBALS['__page_test_saved_bugs'] ?? [];
+            $this->assertCount(1, $saved);
+            $this->assertInstanceOf(\SelectedBug::class, $saved[0]);
+            $this->assertSame($student, $saved[0]->user);
+            $this->assertSame($year, $saved[0]->year);
+            $this->assertSame('https://example.org/issues/99', $saved[0]->issue_url);
+            $this->assertSame('', $saved[0]->repro_url);
+            $this->assertSame('New bug description', $saved[0]->description);
+
+            $this->assertCount(1, $GLOBALS['table']);
+            $this->assertSame('Bob Student', $GLOBALS['table'][0]['Student']);
+            $this->assertSame('https://example.org/issues/99', $GLOBALS['table'][0]['Issue']['url']);
+        } finally {
+            $GLOBALS['entityManager'] = $oldEntityManager;
+        }
+    }
+
+    public function testBugsPageTerminatesWhenStudentSubmitsWithoutGroup()
+    {
+        $year = get_current_year();
+        $student = $this->createPageUser('ist9603', 'Lonely Student', ROLE_STUDENT);
+
+        $deadline = new \Deadline($year);
+        $deadline->bug_selection = new \DateTimeImmutable('+1 day');
+
+        $oldEntityManager = $this->mockBugsEntityManager(
+            deadline: $deadline,
+            bugsByUser: [],
+            bugsByIssue: []
+        );
+
+        try {
+            $this->setUpPageRuntime(
+                'bugs',
+                $student,
+                'POST',
+                [],
+                [
+                    'form' => [
+                        'issue_url' => 'https://example.org/issues/123',
+                        'repro_url' => '',
+                        'description' => 'No group bug',
+                        'submit' => '',
+                    ],
+                ]
+            );
+
+            $this->expectException(PageTerminated::class);
+            $this->expectExceptionMessage('Student is not in a group');
+            $this->runPage('bugs');
+        } finally {
+            $GLOBALS['entityManager'] = $oldEntityManager;
+        }
+    }
+
+    private function createGroup(int $number, int $year, array $students): \ProjGroup
+    {
+        return $this->createPageGroup($number, $year, $students, groupId: $number);
+    }
+
+    private function mockBugsEntityManager(
+        \Deadline $deadline,
+        array $bugsByUser,
+        array $bugsByIssue
+    ): mixed {
+        $oldEntityManager = $GLOBALS['entityManager'] ?? null;
+        $GLOBALS['__page_test_saved_bugs'] = [];
+        $GLOBALS['entityManager'] = new class($deadline, $bugsByUser, $bugsByIssue) {
+            public function __construct(
+                public \Deadline $deadline,
+                public array $bugsByUser,
+                public array $bugsByIssue
+            ) {}
+
+            public function find(string $entity, $id): mixed
+            {
+                if ($entity === 'Deadline') {
+                    return $this->deadline;
+                }
+
+                return null;
+            }
+
+            public function createQueryBuilder(): object
+            {
+                return new class($this) {
+                    private array $params = [];
+
+                    public function __construct(private object $parent) {}
+                    public function from($entity, $alias): self { return $this; }
+                    public function select($select): self { return $this; }
+                    public function where($where): self { return $this; }
+                    public function andWhere($where): self { return $this; }
+                    public function setParameter($name, $value): self
+                    {
+                        $this->params[$name] = $value;
+                        return $this;
+                    }
+                    public function getQuery(): self { return $this; }
+                    public function getOneOrNullResult(): ?\SelectedBug
+                    {
+                        if (isset($this->params['url'])) {
+                            return $this->parent->bugsByIssue[$this->params['url']] ?? null;
+                        }
+                        if (isset($this->params['user'])) {
+                            return $this->parent->bugsByUser[$this->params['user']] ?? null;
+                        }
+                        return null;
+                    }
+                };
+            }
+
+            public function persist($obj): void
+            {
+                if ($obj instanceof \SelectedBug) {
+                    $this->bugsByUser[$obj->user->id] = $obj;
+                    $this->bugsByIssue[$obj->issue_url] = $obj;
+                    $GLOBALS['__page_test_saved_bugs'][] = $obj;
+                }
+            }
+
+            public function flush(): void
+            {
+            }
+        };
+
+        return $oldEntityManager;
+    }
+}

--- a/tests/Integration/Pages/ChangeRolePageTest.php
+++ b/tests/Integration/Pages/ChangeRolePageTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Tests\Integration\Pages;
+
+
+
+class ChangeRolePageTest extends PageTestCase
+{
+    public function testChangeRolePageUpdatesUserRole()
+    {
+        $target = $this->createPageUser('ist9940', 'Student Target', ROLE_STUDENT);
+        $oldEntityManager = $this->mockChangeRoleEntityManager($target);
+
+        try {
+            $prof = $this->createPageUser('ist9941', 'Professor Admin', ROLE_PROF);
+            $this->setUpPageRuntime(
+                'changerole',
+                $prof,
+                'POST',
+                [],
+                [
+                    'form' => [
+                        'username' => $target->id,
+                        'role' => '2',
+                        'submit' => '',
+                    ],
+                ]
+            );
+            $this->runPage('changerole');
+
+            $this->assertSame(ROLE_TA, $target->role);
+            $this->assertSame('Changed role successfully!', $GLOBALS['success_message']);
+            $this->assertSame(1, $GLOBALS['entityManager']->flushCount);
+        } finally {
+            $GLOBALS['entityManager'] = $oldEntityManager;
+        }
+    }
+
+    private function mockChangeRoleEntityManager(\User $target): mixed
+    {
+        $oldEntityManager = $GLOBALS['entityManager'] ?? null;
+        $GLOBALS['entityManager'] = new class($target) {
+            public int $flushCount = 0;
+
+            public function __construct(private \User $target) {}
+
+            public function find(string $entity, $id): mixed
+            {
+                if ($entity === 'User' && $id === $this->target->id) {
+                    return $this->target;
+                }
+
+                return null;
+            }
+
+            public function flush(): void
+            {
+                $this->flushCount++;
+            }
+        };
+
+        return $oldEntityManager;
+    }
+}

--- a/tests/Integration/Pages/CronPageTest.php
+++ b/tests/Integration/Pages/CronPageTest.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace Tests\Integration\Pages;
+
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+
+
+class CronPageTest extends PageTestCase
+{
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testCronPageBuildsRunLinksWhenNoTaskIsSelected()
+    {
+        [$oldWorkingDirectory, $stubDir] = $this->setUpCronStubDirectory();
+
+        try {
+            $prof = $this->createPageUser('ist9970', 'Professor Cron', ROLE_PROF);
+            $this->setUpPageRuntime('cron', $prof);
+            $this->runPage('cron');
+
+            $this->assertCount(2, $GLOBALS['lists']['Run']);
+            $this->assertSame('Prune cache', $GLOBALS['lists']['Run'][0]['label']);
+            $this->assertSame(
+                'index.php?task=prune_cache&page=cron',
+                $GLOBALS['lists']['Run'][0]['url']
+            );
+            $this->assertSame('Update repository information', $GLOBALS['lists']['Run'][1]['label']);
+            $this->assertSame(
+                'index.php?task=repository&page=cron',
+                $GLOBALS['lists']['Run'][1]['url']
+            );
+            $this->assertSame('', $GLOBALS['monospace']);
+            $this->assertNull($GLOBALS['success_message']);
+            $this->assertNull($GLOBALS['info_message']);
+        } finally {
+            $this->tearDownCronStubDirectory($oldWorkingDirectory, $stubDir);
+        }
+    }
+
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testCronPageShowsContinuationMessageWhenCheckpointIsPresent()
+    {
+        [$oldWorkingDirectory, $stubDir] = $this->setUpCronStubDirectory();
+
+        try {
+            $prof = $this->createPageUser('ist9971', 'Professor Cron', ROLE_PROF);
+            $this->setUpPageRuntime('cron', $prof, 'GET', ['checkpoint' => 15]);
+            $this->runPage('cron');
+
+            $this->assertSame('Continuing with offset 15...', $GLOBALS['info_message']);
+            $this->assertSame('', $GLOBALS['monospace']);
+            $this->assertCount(2, $GLOBALS['lists']['Run']);
+        } finally {
+            $this->tearDownCronStubDirectory($oldWorkingDirectory, $stubDir);
+        }
+    }
+
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testCronPageMarksTaskAsDoneAndCapturesOutput()
+    {
+        [$oldWorkingDirectory, $stubDir] = $this->setUpCronStubDirectory('success');
+
+        try {
+            $prof = $this->createPageUser('ist9972', 'Professor Cron', ROLE_PROF);
+            $this->setUpPageRuntime('cron', $prof, 'GET', ['task' => 'repository']);
+            $this->runPage('cron');
+
+            $this->assertSame('All done!', $GLOBALS['success_message']);
+            $this->assertSame("Running requested cron task\n", $GLOBALS['monospace']);
+            $this->assertNull($GLOBALS['refresh_url']);
+            $this->assertCount(2, $GLOBALS['lists']['Run']);
+        } finally {
+            $this->tearDownCronStubDirectory($oldWorkingDirectory, $stubDir);
+        }
+    }
+
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testCronPageBuildsRefreshUrlWhenCheckpointExceptionIsThrown()
+    {
+        [$oldWorkingDirectory, $stubDir] = $this->setUpCronStubDirectory('checkpoint');
+
+        try {
+            $prof = $this->createPageUser('ist9973', 'Professor Cron', ROLE_PROF);
+            $this->setUpPageRuntime('cron', $prof, 'GET', ['task' => 'repository']);
+            $this->runPage('cron');
+
+            $this->assertSame(
+                'index.php?task=repository&checkpoint=42&page=cron',
+                $GLOBALS['refresh_url']
+            );
+            $this->assertSame('Will continue with offset 42...', $GLOBALS['info_message']);
+            $this->assertSame("Processed chunk before checkpoint\n", $GLOBALS['monospace']);
+            $this->assertNull($GLOBALS['success_message']);
+        } finally {
+            $this->tearDownCronStubDirectory($oldWorkingDirectory, $stubDir);
+        }
+    }
+
+    private function setUpCronStubDirectory(string $mode = 'default'): array
+    {
+        $oldWorkingDirectory = getcwd();
+        $stubDir = sys_get_temp_dir() . '/pic1_cron_stubs_' . bin2hex(random_bytes(4));
+        mkdir($stubDir);
+
+        $modeExport = var_export($mode, true);
+        $code = <<<PHP
+<?php
+if (!class_exists('CheckPointException', false)) {
+    class CheckPointException extends Exception
+    {
+        public int \$idx;
+
+        public function __construct(int \$idx)
+        {
+            \$this->idx = \$idx;
+            parent::__construct();
+        }
+    }
+}
+
+\$tasks = [
+    'prune_cache' => 'Prune cache',
+    'repository' => 'Update repository information',
+];
+
+\$mode = $modeExport;
+if (\$mode === 'success') {
+    echo "Running requested cron task\\n";
+} elseif (\$mode === 'checkpoint') {
+    echo "Processed chunk before checkpoint\\n";
+    throw new CheckPointException(42);
+}
+PHP;
+
+        file_put_contents($stubDir . '/cron.php', $code);
+        chdir($stubDir);
+
+        return [$oldWorkingDirectory, $stubDir];
+    }
+
+    private function tearDownCronStubDirectory(string|false $oldWorkingDirectory, string $stubDir): void
+    {
+        if ($oldWorkingDirectory !== false) {
+            chdir($oldWorkingDirectory);
+        }
+        @unlink($stubDir . '/cron.php');
+        @rmdir($stubDir);
+    }
+}

--- a/tests/Integration/Pages/DashboardPageTest.php
+++ b/tests/Integration/Pages/DashboardPageTest.php
@@ -1,0 +1,273 @@
+<?php
+
+namespace Tests\Integration\Pages;
+
+
+
+
+require_once dirname(__DIR__, 3) . '/entities/Patch.php';
+
+class DashboardPageTest extends PageTestCase
+{
+    public function testDashboardBuildsPlotsAndProjectTable()
+    {
+        $oldClient = $this->mockCachedGitHubClientForDashboard();
+        $oldEntityManager = $this->mockDashboardEntityManager(
+            mergedPatchStats: [
+                [
+                    'year' => 2023,
+                    'patches' => 10,
+                    'lines_added' => 1_200,
+                    'lines_deleted' => 300,
+                    'files_modified' => 45,
+                ],
+                [
+                    'year' => 2024,
+                    'patches' => 20,
+                    'lines_added' => 2_000,
+                    'lines_deleted' => 500,
+                    'files_modified' => 60,
+                ],
+            ],
+            patchStats: [
+                [
+                    'year' => 2023,
+                    'status' => \PatchStatus::Merged,
+                    'type' => \PatchType::BugFix,
+                    'count' => 3,
+                ],
+                [
+                    'year' => 2023,
+                    'status' => \PatchStatus::PROpen,
+                    'type' => \PatchType::BugFix,
+                    'count' => 1,
+                ],
+                [
+                    'year' => 2024,
+                    'status' => \PatchStatus::MergedIllegal,
+                    'type' => \PatchType::Feature,
+                    'count' => 2,
+                ],
+                [
+                    'year' => 2024,
+                    'status' => \PatchStatus::NotMerged,
+                    'type' => \PatchType::Feature,
+                    'count' => 2,
+                ],
+                [
+                    'year' => 2024,
+                    'status' => \PatchStatus::WaitingReview,
+                    'type' => \PatchType::BugFix,
+                    'count' => 99,
+                ],
+            ],
+            groups: $this->createDashboardGroups(),
+            prStats: [
+                [
+                    'status' => \PatchStatus::Merged,
+                    'type' => \PatchType::BugFix,
+                    'repository' => 'github:owner/repo-a',
+                    'count' => 3,
+                ],
+                [
+                    'status' => \PatchStatus::PROpen,
+                    'type' => \PatchType::BugFix,
+                    'repository' => 'github:owner/repo-a',
+                    'count' => 1,
+                ],
+                [
+                    'status' => \PatchStatus::MergedIllegal,
+                    'type' => \PatchType::Feature,
+                    'repository' => 'github:owner/repo-a',
+                    'count' => 2,
+                ],
+                [
+                    'status' => \PatchStatus::NotMerged,
+                    'type' => \PatchType::Feature,
+                    'repository' => 'github:owner/repo-a',
+                    'count' => 2,
+                ],
+                [
+                    'status' => \PatchStatus::Merged,
+                    'type' => \PatchType::BugFix,
+                    'repository' => 'github:owner/repo-b',
+                    'count' => 1,
+                ],
+            ]
+        );
+
+        $GLOBALS['__page_test_filter_result'] = 2024;
+        $this->setUpPageRuntime(
+            'dashboard',
+            $this->createPageUser('ist8000', 'Professor Dashboard', ROLE_PROF)
+        );
+
+        try {
+            $this->runPage('dashboard');
+            $this->fail('dashboard.php should terminate with rendered fields');
+        } catch (PageTerminated $terminated) {
+            $this->assertSame('dashboard.html.twig', $terminated->template);
+            $fields = $terminated->extraFields;
+
+            $this->assertSame(['2023/2024', '2024/2025'], $fields['merged_prs_years']);
+            $this->assertSame([10, 20], $fields['merged_prs_patches']);
+            $this->assertSame([1200, 2000], $fields['merged_prs_lines_added']);
+            $this->assertSame([300, 500], $fields['merged_prs_lines_deleted']);
+            $this->assertSame([45, 60], $fields['merged_prs_files_modified']);
+            $this->assertSame(22.0, $fields['max_y']);
+            $this->assertSame(2200.0, $fields['max_y2']);
+            $this->assertSame("3\u{202F}k", $fields['total_lines_code']);
+
+            $this->assertSame('5', (string)$fields['total_merged_prs']);
+            $this->assertSame(['2023/2024', '2024/2025'], $fields['pcmerged_x']);
+            $this->assertSame([0.75], $fields['pcmerged_bug']);
+            $this->assertSame([0.5], $fields['pcmerged_feat']);
+
+            $this->assertSame(['PHP', 'Rust'], $fields['lang_x']);
+            $this->assertSame([1, 1], array_values($fields['lang_y']));
+            $this->assertSame(['owner/repo-a', 'owner/repo-b'], $fields['proj_x']);
+            $this->assertSame([1, 1], array_values($fields['proj_y']));
+
+            $this->assertCount(2, $fields['all_projects']);
+            $this->assertSame(
+                [
+                    'id' => 0,
+                    'name' => 'owner/repo-a',
+                    'total_bugs' => 4,
+                    'total_feat' => 4,
+                    'bugs' => 3,
+                    'feat' => 2,
+                    'bugs_pc' => 75.0,
+                    'feat_pc' => 50.0,
+                    'url' => 'https://github.com/owner/repo-a',
+                ],
+                $fields['all_projects'][0]
+            );
+            $this->assertSame(
+                [
+                    'id' => 1,
+                    'name' => 'owner/repo-b',
+                    'total_bugs' => 1,
+                    'total_feat' => 0,
+                    'bugs' => 1,
+                    'feat' => 0,
+                    'bugs_pc' => 100.0,
+                    'feat_pc' => 0,
+                    'url' => 'https://github.com/owner/repo-b',
+                ],
+                $fields['all_projects'][1]
+            );
+        } finally {
+            $GLOBALS['github_client_cached'] = $oldClient;
+            $GLOBALS['entityManager'] = $oldEntityManager;
+        }
+    }
+
+    private function createDashboardGroups(): array
+    {
+        $shift = new \Shift('T1', 2024);
+
+        $groupA = new \ProjGroup(1, 2024, $shift);
+        $groupA->id = 100;
+        $groupA->repository = 'github:owner/repo-a';
+
+        $groupB = new \ProjGroup(2, 2024, $shift);
+        $groupB->id = 200;
+        $groupB->repository = 'github:owner/repo-b';
+
+        return [$groupA, $groupB];
+    }
+
+    private function mockDashboardEntityManager(
+        array $mergedPatchStats,
+        array $patchStats,
+        array $groups,
+        array $prStats
+    ): mixed {
+        $oldEntityManager = $GLOBALS['entityManager'] ?? null;
+        $GLOBALS['entityManager'] = new class($mergedPatchStats, $patchStats, $groups, $prStats) {
+            public function __construct(
+                private array $mergedPatchStats,
+                private array $patchStats,
+                private array $groups,
+                private array $prStats
+            ) {}
+
+            public function createQueryBuilder(): object
+            {
+                static $call = 0;
+                $datasets = [
+                    $this->mergedPatchStats,
+                    $this->patchStats,
+                    $this->prStats,
+                ];
+
+                return new class($datasets[$call++] ?? []) {
+                    public function __construct(private array $result) {}
+                    public function from($entity, $alias): self { return $this; }
+                    public function where($where): self { return $this; }
+                    public function select($select): self { return $this; }
+                    public function join($join, $alias): self { return $this; }
+                    public function groupBy($groupBy): self { return $this; }
+                    public function orderBy($orderBy, $direction = null): self { return $this; }
+                    public function setParameter($name, $value): self { return $this; }
+                    public function getQuery(): self { return $this; }
+                    public function getArrayResult(): array { return $this->result; }
+                };
+            }
+
+            public function getRepository(string $entity): object
+            {
+                if ($entity === 'ProjGroup') {
+                    return new class($this->groups) {
+                        public function __construct(private array $groups) {}
+                        public function findByYear($year, $order): array
+                        {
+                            return $this->groups;
+                        }
+                    };
+                }
+
+                throw new \RuntimeException("Unexpected repository lookup: $entity");
+            }
+        };
+
+        return $oldEntityManager;
+    }
+
+    private function mockCachedGitHubClientForDashboard(): mixed
+    {
+        $oldClient = $GLOBALS['github_client_cached'] ?? null;
+        $GLOBALS['github_client_cached'] = new class {
+            public function api($endpoint)
+            {
+                return new class {
+                    public function show($owner, $repo)
+                    {
+                        $language = $repo === 'repo-a' ? 'PHP' : 'Rust';
+                        return [
+                            'full_name' => "$owner/$repo",
+                            'default_branch' => 'main',
+                            'language' => $language,
+                            'license' => ['name' => 'MIT'],
+                            'stargazers_count' => 123,
+                            'topics' => ['testing'],
+                        ];
+                    }
+
+                    public function languages($owner, $repo)
+                    {
+                        return ['PHP' => 4_000];
+                    }
+
+                    public function participation($owner, $repo)
+                    {
+                        return ['all' => array_fill(0, 52, 1)];
+                    }
+                };
+            }
+        };
+
+        return $oldClient;
+    }
+}

--- a/tests/Integration/Pages/DeadlinesPageTest.php
+++ b/tests/Integration/Pages/DeadlinesPageTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Tests\Integration\Pages;
+
+
+
+class DeadlinesPageTest extends PageTestCase
+{
+    public function testDeadlinesPageBuildsFormWithReadonlyYear()
+    {
+        $year = get_current_year();
+        $deadline = new \Deadline($year);
+        $oldEntityManager = $this->mockDeadlineEntityManager($deadline);
+
+        try {
+            $this->setUpPageRuntime(
+                'deadlines',
+                $this->createPageUser('ist9000', 'Professor Deadlines', ROLE_PROF)
+            );
+            $this->runPage('deadlines');
+
+            $this->assertSame($year, $GLOBALS['__page_test_deadline_year']);
+            $this->assertNotNull($GLOBALS['form']);
+            $this->assertTrue($GLOBALS['form']->has('year'));
+            $this->assertTrue($GLOBALS['form']->has('proj_proposal'));
+            $this->assertTrue($GLOBALS['form']->has('bug_selection'));
+            $this->assertTrue($GLOBALS['form']->has('feature_selection'));
+            $this->assertTrue($GLOBALS['form']->has('patch_submission'));
+            $this->assertTrue($GLOBALS['form']->has('final_report'));
+            $this->assertTrue($GLOBALS['form']->has('submit'));
+            $this->assertTrue($GLOBALS['form']->get('year')->getConfig()->getOption('disabled'));
+            $this->assertFalse($GLOBALS['form']->get('submit')->getConfig()->getOption('disabled'));
+            $this->assertNull($GLOBALS['success_message']);
+        } finally {
+            $GLOBALS['entityManager'] = $oldEntityManager;
+        }
+    }
+
+    public function testDeadlinesPageUpdatesEditableFieldsButKeepsYearReadonly()
+    {
+        $year = get_current_year();
+        $deadline = new \Deadline($year);
+        $deadline->proj_proposal = new \DateTimeImmutable('2025-01-01 10:00');
+        $deadline->bug_selection = new \DateTimeImmutable('2025-01-02 10:00');
+        $deadline->feature_selection = new \DateTimeImmutable('2025-01-03 10:00');
+        $deadline->patch_submission = new \DateTimeImmutable('2025-01-04 10:00');
+        $deadline->final_report = new \DateTimeImmutable('2025-01-05 10:00');
+
+        $oldEntityManager = $this->mockDeadlineEntityManager($deadline);
+
+        try {
+            $this->setUpPageRuntime(
+                'deadlines',
+                $this->createPageUser('ist9001', 'Professor Editor', ROLE_PROF),
+                'POST',
+                [],
+                [
+                    'form' => [
+                        'year' => '1999',
+                        'proj_proposal' => '2025-06-01T09:30',
+                        'bug_selection' => '2025-06-02T10:30',
+                        'feature_selection' => '2025-06-03T11:30',
+                        'patch_submission' => '2025-06-04T12:30',
+                        'final_report' => '2025-06-05T13:30',
+                        'submit' => '',
+                    ],
+                ]
+            );
+            $this->runPage('deadlines');
+
+            $this->assertSame($year, $deadline->year);
+            $this->assertSame('2025-06-01 09:30', $deadline->proj_proposal->format('Y-m-d H:i'));
+            $this->assertSame('2025-06-02 10:30', $deadline->bug_selection->format('Y-m-d H:i'));
+            $this->assertSame('2025-06-03 11:30', $deadline->feature_selection->format('Y-m-d H:i'));
+            $this->assertSame('2025-06-04 12:30', $deadline->patch_submission->format('Y-m-d H:i'));
+            $this->assertSame('2025-06-05 13:30', $deadline->final_report->format('Y-m-d H:i'));
+            $this->assertSame('Database updated!', $GLOBALS['success_message']);
+            $this->assertTrue($GLOBALS['form']->get('year')->getConfig()->getOption('disabled'));
+        } finally {
+            $GLOBALS['entityManager'] = $oldEntityManager;
+        }
+    }
+
+    private function mockDeadlineEntityManager(\Deadline $deadline): mixed
+    {
+        $oldEntityManager = $GLOBALS['entityManager'] ?? null;
+        $GLOBALS['entityManager'] = new class($deadline) {
+            public function __construct(private \Deadline $deadline) {}
+
+            public function find(string $entity, $id): mixed
+            {
+                if ($entity === 'Deadline') {
+                    $GLOBALS['__page_test_deadline_year'] = $id;
+                    return $this->deadline;
+                }
+
+                return null;
+            }
+        };
+
+        return $oldEntityManager;
+    }
+}

--- a/tests/Integration/Pages/DiscoverPageTest.php
+++ b/tests/Integration/Pages/DiscoverPageTest.php
@@ -1,0 +1,205 @@
+<?php
+
+namespace Tests\Integration\Pages;
+
+use Tests\Mocks\MockGitHubClient;
+require_once dirname(__DIR__, 3) . '/entities/Patch.php';
+
+class DiscoverPageTest extends PageTestCase
+{
+    public function testDiscoverPageBuildsSearchFormAndTerminatesWithTemplate()
+    {
+        $this->setUpPageRuntime(
+            'discover',
+            $this->createPageUser('ist9500', 'Student Discover', ROLE_STUDENT)
+        );
+
+        try {
+            $this->runPage('discover');
+            $this->fail('discover.php should terminate with discover template fields');
+        } catch (PageTerminated $terminated) {
+            $this->assertSame('discover.html.twig', $terminated->template);
+            $fields = $terminated->extraFields;
+
+            $this->assertArrayHasKey('form', $fields);
+            $this->assertArrayNotHasKey('projects', $fields);
+            $this->assertArrayNotHasKey('topics', $fields);
+            $this->assertArrayNotHasKey('language', $fields);
+            $this->assertNull($terminated->errorMessage);
+        }
+    }
+
+    public function testDiscoverPageBuildsProjectsTopicsAndPatchSummary()
+    {
+        $oldClient = $this->mockDiscoverGitHubClient();
+        $oldEntityManager = $this->mockDiscoverEntityManager([
+            'github:owner/repo-a' => [
+                ['status' => \PatchStatus::Merged, 'patches' => 2],
+                ['status' => \PatchStatus::MergedIllegal, 'patches' => 1],
+                ['status' => \PatchStatus::PROpen, 'patches' => 1],
+            ],
+            'github:owner/repo-b' => [],
+        ]);
+
+        try {
+            $this->setUpPageRuntime(
+                'discover',
+                $this->createPageUser('ist9501', 'Student Search', ROLE_STUDENT),
+                'GET',
+                [
+                    'keywords' => 'api',
+                    'language' => 'PHP',
+                    'newbies' => '1',
+                    'search' => '',
+                ]
+            );
+
+            $this->runPage('discover');
+            $this->fail('discover.php should terminate with discover template fields');
+        } catch (PageTerminated $terminated) {
+            $this->assertSame('discover.html.twig', $terminated->template);
+            $fields = $terminated->extraFields;
+
+            $this->assertSame('PHP', $fields['language']);
+            $this->assertArrayHasKey('topics', $fields);
+            $topics = $fields['topics'];
+            sort($topics);
+            $this->assertSame(['backend', 'cli', 'php'], $topics);
+
+            $this->assertArrayHasKey('projects', $fields);
+            $this->assertCount(2, $fields['projects']);
+
+            $projectsByName = [];
+            foreach ($fields['projects'] as $project) {
+                $projectsByName[$project['name']] = $project;
+            }
+
+            $this->assertSame('4 (75% merged)', $projectsByName['github:owner/repo-a']['patches']);
+            $this->assertSame('none', $projectsByName['github:owner/repo-b']['patches']);
+            $this->assertSame('https://github.com/owner/repo-a', $projectsByName['github:owner/repo-a']['url']);
+            $this->assertSame('https://github.com/owner/repo-b', $projectsByName['github:owner/repo-b']['url']);
+        } finally {
+            $GLOBALS['github_client_cached'] = $oldClient;
+            $GLOBALS['entityManager'] = $oldEntityManager;
+        }
+    }
+
+    public function testDiscoverPageTerminatesWithSearchError()
+    {
+        $oldClient = $GLOBALS['github_client_cached'] ?? null;
+        $GLOBALS['github_client_cached'] = new class {
+            public function api($endpoint)
+            {
+                return new class {
+                    public function repositories($query, $sort = null, $order = null)
+                    {
+                        throw new \Exception('GitHub search failed');
+                    }
+                };
+            }
+        };
+
+        try {
+            $this->setUpPageRuntime(
+                'discover',
+                $this->createPageUser('ist9502', 'Student Error', ROLE_STUDENT),
+                'GET',
+                [
+                    'keywords' => 'broken',
+                    'language' => 'PHP',
+                    'search' => '',
+                ]
+            );
+
+            try {
+                $this->runPage('discover');
+                $this->fail('discover.php should terminate on search error');
+            } catch (PageTerminated $terminated) {
+                $this->assertSame('GitHub search failed', $terminated->errorMessage);
+                $this->assertSame('discover.html.twig', $terminated->template);
+                $this->assertArrayHasKey('form', $terminated->extraFields);
+            }
+        } finally {
+            $GLOBALS['github_client_cached'] = $oldClient;
+        }
+    }
+
+    private function mockDiscoverGitHubClient(): mixed
+    {
+        $oldClient = $GLOBALS['github_client_cached'] ?? null;
+        $activity = [
+            'all' => array_merge(array_fill(0, 48, 0), [10, 10, 10, 10]),
+            'owner' => array_fill(0, 52, 0),
+        ];
+        $GLOBALS['github_client_cached'] = new MockGitHubClient(
+            searchResults: ['items' => [
+                [
+                    'full_name' => 'owner/repo-a',
+                    'description' => 'First mock repository',
+                    'html_url' => 'https://github.com/owner/repo-a',
+                    'stargazers_count' => 1200,
+                    'open_issues' => 42,
+                    'language' => 'PHP',
+                    'topics' => ['php', 'backend'],
+                    'pushed_at' => '2026-04-26T10:00:00+00:00',
+                ],
+                [
+                    'full_name' => 'owner/repo-b',
+                    'description' => 'Second mock repository',
+                    'html_url' => 'https://github.com/owner/repo-b',
+                    'stargazers_count' => 800,
+                    'open_issues' => 8,
+                    'language' => 'PHP',
+                    'topics' => ['cli', 'php'],
+                    'pushed_at' => '2026-04-27T11:00:00+00:00',
+                ],
+            ]],
+            languagesByRepository: [
+                'owner/repo-a' => ['PHP' => 4_800_000],
+                'owner/repo-b' => ['PHP' => 4_800_000],
+            ],
+            participationByRepository: [
+                'owner/repo-a' => $activity,
+                'owner/repo-b' => $activity,
+            ]
+        );
+
+        return $oldClient;
+    }
+
+    private function mockDiscoverEntityManager(array $patchStatsByRepo): mixed
+    {
+        $oldEntityManager = $GLOBALS['entityManager'] ?? null;
+        $GLOBALS['entityManager'] = new class($patchStatsByRepo) {
+            public function __construct(private array $patchStatsByRepo) {}
+
+            public function createQueryBuilder(): object
+            {
+                return new class($this->patchStatsByRepo) {
+                    private ?string $repo = null;
+
+                    public function __construct(private array $patchStatsByRepo) {}
+                    public function from($entity, $alias): self { return $this; }
+                    public function select($select): self { return $this; }
+                    public function where($where): self { return $this; }
+                    public function join($join, $alias): self { return $this; }
+                    public function groupBy($groupBy): self { return $this; }
+                    public function setParameter($name, $value): self
+                    {
+                        if ($name === 'repo') {
+                            $this->repo = $value;
+                        }
+                        return $this;
+                    }
+                    public function getQuery(): self { return $this; }
+                    public function getArrayResult(): array
+                    {
+                        return $this->patchStatsByRepo[$this->repo] ?? [];
+                    }
+                };
+            }
+        };
+
+        return $oldEntityManager;
+    }
+}

--- a/tests/Integration/Pages/EditPatchPageTest.php
+++ b/tests/Integration/Pages/EditPatchPageTest.php
@@ -1,0 +1,634 @@
+<?php
+
+namespace Tests\Integration\Pages;
+
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+use Tests\Integration\Pages\PageRedirected;
+use Tests\Mocks\FakePatch;
+use Tests\Mocks\FakePullRequest;
+
+
+require_once dirname(__DIR__, 3) . '/entities/Patch.php';
+
+class EditPatchPageTest extends PageTestCase
+{
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testEditPatchProfessorBuildsReviewControlsAndPatchDetails()
+    {
+        [$oldWorkingDirectory, $stubDir] = $this->setUpEditPatchStubDirectory();
+        $year = get_current_year();
+        $prof = $this->createPageUser('ist9920', 'Professor Reviewer', ROLE_PROF);
+        $prof->email = 'prof@example.com';
+        $student = $this->createPageUser('ist9921', 'Alice Student', ROLE_STUDENT);
+        $student->email = 'alice@example.com';
+
+        $group = $this->createEditPatchGroup($year, $student, $prof);
+        $group->hash_proposal_file = 'proposalhash';
+
+        $patch = $this->createPatchStub(
+            group: $group,
+            submitter: $student,
+            status: \PatchStatus::Reviewed,
+            type: \PatchType::Feature,
+            valid: true,
+            pr: $this->createPullRequestStub('https://github.com/owner/repo/pull/12'),
+            commits: [[
+                'username' => 'alice',
+                'name' => 'Alice Student',
+                'email' => 'alice@example.com',
+                'co-authored' => [],
+            ]]
+        );
+        $patch->comments->add(new \PatchComment($patch, 'Automated review note', null));
+        $patch->ci_failures->add(new \PatchCIError(
+            $patch,
+            'abc123',
+            'lint',
+            'https://ci.example/lint',
+            new \DateTimeImmutable('2026-01-01 10:00:00')
+        ));
+        $patch->ci_failures->add(new \PatchCIError(
+            $patch,
+            'abc123',
+            'tests',
+            'https://ci.example/tests',
+            new \DateTimeImmutable('2026-01-01 11:00:00')
+        ));
+
+        $oldEntityManager = $this->mockEditPatchEntityManager($patch, $year);
+
+        try {
+            $this->setUpPageRuntime('editpatch', $prof, 'GET', ['id' => $patch->id]);
+            $this->runPage('editpatch');
+
+            $this->assertNotNull($GLOBALS['comments_form']);
+            $this->assertTrue($GLOBALS['comments_form']->has('approve'));
+            $this->assertTrue($GLOBALS['comments_form']->has('reject'));
+
+            $this->assertCount(2, $GLOBALS['comments']);
+            $this->assertSame('Alice Student (ist9921)', $GLOBALS['comments'][0]['author']);
+            $this->assertSame('', $GLOBALS['comments'][1]['author']);
+            $this->assertStringContainsString('bottts', $GLOBALS['comments'][1]['photo']);
+
+            $this->assertSame(
+                'https://github.com/owner/repo/commit/abc123',
+                $GLOBALS['ci_failures']['abc123']['url']
+            );
+            $this->assertSame(
+                'https://ci.example/lint',
+                $GLOBALS['ci_failures']['abc123']['failed']['lint']
+            );
+            $this->assertSame(
+                'https://ci.example/tests',
+                $GLOBALS['ci_failures']['abc123']['failed']['tests']
+            );
+
+            $this->assertCount(1, $GLOBALS['bottom_links']);
+            $this->assertSame('Delete patch', $GLOBALS['bottom_links'][0]['label']);
+            $this->assertSame(
+                'index.php?id=9101&page=rmpatch',
+                $GLOBALS['bottom_links'][0]['url']
+            );
+
+            $this->assertSame('Statistics', $GLOBALS['info_box']['title']);
+            $this->assertSame(8, $GLOBALS['info_box']['rows']['Lines added']);
+            $this->assertSame(2, $GLOBALS['info_box']['rows']['Lines removed']);
+            $this->assertSame(1, $GLOBALS['info_box']['rows']['Files modified']);
+            $this->assertSame(
+                ['warn' => true, 'data' => 'Alice Student <alice@example.com>'],
+                $GLOBALS['info_box']['rows']['All authors']
+            );
+            $this->assertSame(
+                'https://github.com/owner/repo/tree/feature-branch',
+                $GLOBALS['info_box']['rows']['Patch']['url']
+            );
+            $this->assertSame(
+                'https://github.com/owner/repo/pull/12',
+                $GLOBALS['info_box']['rows']['PR']['url']
+            );
+            $this->assertSame(
+                'https://example.org/issues/51',
+                $GLOBALS['info_box']['rows']['Issue']['url']
+            );
+            $this->assertSame(
+                'index.php?download=5100&page=feature',
+                $GLOBALS['embed_file']
+            );
+
+            $this->assertCount(1, $GLOBALS['__page_test_eval_boxes']);
+            $this->assertSame('patch-feature', $GLOBALS['__page_test_eval_boxes'][0]['page']);
+            $this->assertSame($student, $GLOBALS['__page_test_eval_boxes'][0]['student']);
+            $this->assertSame($group, $GLOBALS['__page_test_eval_boxes'][0]['group']);
+        } finally {
+            $GLOBALS['entityManager'] = $oldEntityManager;
+            $this->tearDownEditPatchStubDirectory($oldWorkingDirectory, $stubDir);
+        }
+    }
+
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testEditPatchStudentCommentResubmitsReviewedPatchAndNotifiesTa()
+    {
+        [$oldWorkingDirectory, $stubDir] = $this->setUpEditPatchStubDirectory();
+        $year = get_current_year();
+        $student = $this->createPageUser('ist9930', 'Alice Student', ROLE_STUDENT);
+        $ta = $this->createPageUser('ist9931', 'Taylor Assistant', ROLE_TA);
+        $ta->email = 'ta@example.com';
+
+        $group = $this->createEditPatchGroup($year, $student, $ta);
+        $patch = $this->createPatchStub(
+            group: $group,
+            submitter: $student,
+            status: \PatchStatus::Reviewed
+        );
+
+        $oldEntityManager = $this->mockEditPatchEntityManager($patch, $year);
+        $GLOBALS['patch'] = $patch;
+        $GLOBALS['__editpatch_emails'] = [];
+
+        try {
+            $this->setUpPageRuntime(
+                'editpatch',
+                $student,
+                'POST',
+                ['id' => $patch->id],
+                [
+                    'comments' => [
+                        'text' => 'I updated the patch after the review.',
+                        'submit' => '',
+                    ],
+                ]
+            );
+
+            try {
+                $this->runPage('editpatch');
+                $this->fail('Expected page to redirect after submitting a comment.');
+            } catch (PageRedirected) {
+            }
+
+            $latestComment = $patch->comments->last()->text;
+
+            $this->assertSame('waiting review', $patch->getStatus());
+            $this->assertCount(2, $patch->comments);
+            $this->assertStringContainsString(
+                'Status changed: reviewed (not approved) → waiting review',
+                $latestComment
+            );
+            $this->assertStringContainsString(
+                'I updated the patch after the review.',
+                $latestComment
+            );
+            $this->assertSame('PIC1: new patch comment', $GLOBALS['__editpatch_emails'][0]['subject']);
+            $this->assertSame('ta@example.com', $GLOBALS['__editpatch_emails'][0]['to']);
+            $this->assertStringContainsString('Comment history:', $GLOBALS['__editpatch_emails'][0]['msg']);
+        } finally {
+            $GLOBALS['entityManager'] = $oldEntityManager;
+            unset($GLOBALS['patch']);
+            $this->tearDownEditPatchStubDirectory($oldWorkingDirectory, $stubDir);
+        }
+    }
+
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testEditPatchTaApproveCommentApprovesPatchAndEmailsGroup()
+    {
+        [$oldWorkingDirectory, $stubDir] = $this->setUpEditPatchStubDirectory();
+        $year = get_current_year();
+        $student = $this->createPageUser('ist9940', 'Alice Student', ROLE_STUDENT);
+        $ta = $this->createPageUser('ist9941', 'Taylor Assistant', ROLE_TA);
+        $ta->email = 'ta@example.com';
+
+        $group = $this->createEditPatchGroup($year, $student, $ta);
+        $patch = $this->createPatchStub(
+            group: $group,
+            submitter: $student,
+            status: \PatchStatus::Reviewed
+        );
+
+        $oldEntityManager = $this->mockEditPatchEntityManager($patch, $year);
+        $GLOBALS['patch'] = $patch;
+        $GLOBALS['__editpatch_emails'] = [];
+
+        try {
+            $this->setUpPageRuntime(
+                'editpatch',
+                $ta,
+                'POST',
+                ['id' => $patch->id],
+                [
+                    'comments' => [
+                        'text' => 'Looks good now.',
+                        'approve' => '',
+                    ],
+                ]
+            );
+
+            try {
+                $this->runPage('editpatch');
+                $this->fail('Expected page to redirect after approving a patch.');
+            } catch (PageRedirected) {
+            }
+
+            $latestComment = $patch->comments->last()->text;
+
+            $this->assertSame('approved', $patch->getStatus());
+            $this->assertStringContainsString(
+                'Status changed: reviewed (not approved) → approved',
+                $latestComment
+            );
+            $this->assertSame('PIC1: Patch approved', $GLOBALS['__editpatch_emails'][0]['subject']);
+            $this->assertStringContainsString(
+                'Congratulations! Your patch was approved. You can now open a PR.',
+                $GLOBALS['__editpatch_emails'][0]['msg']
+            );
+        } finally {
+            $GLOBALS['entityManager'] = $oldEntityManager;
+            unset($GLOBALS['patch']);
+            $this->tearDownEditPatchStubDirectory($oldWorkingDirectory, $stubDir);
+        }
+    }
+
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testEditPatchTaRejectCommentMarksPatchReviewedAndEmailsGroup()
+    {
+        [$oldWorkingDirectory, $stubDir] = $this->setUpEditPatchStubDirectory();
+        $year = get_current_year();
+        $student = $this->createPageUser('ist9950', 'Alice Student', ROLE_STUDENT);
+        $ta = $this->createPageUser('ist9951', 'Taylor Assistant', ROLE_TA);
+        $ta->email = 'ta@example.com';
+
+        $group = $this->createEditPatchGroup($year, $student, $ta);
+        $patch = $this->createPatchStub(
+            group: $group,
+            submitter: $student,
+            status: \PatchStatus::WaitingReview
+        );
+
+        $oldEntityManager = $this->mockEditPatchEntityManager($patch, $year);
+        $GLOBALS['patch'] = $patch;
+        $GLOBALS['__editpatch_emails'] = [];
+
+        try {
+            $this->setUpPageRuntime(
+                'editpatch',
+                $ta,
+                'POST',
+                ['id' => $patch->id],
+                [
+                    'comments' => [
+                        'text' => 'Please make one more update.',
+                        'reject' => '',
+                    ],
+                ]
+            );
+
+            try {
+                $this->runPage('editpatch');
+                $this->fail('Expected page to redirect after rejecting a patch.');
+            } catch (PageRedirected) {
+            }
+
+            $latestComment = $patch->comments->last()->text;
+
+            $this->assertSame('reviewed (not approved)', $patch->getStatus());
+            $this->assertStringContainsString(
+                'Status changed: waiting review → reviewed (not approved)',
+                $latestComment
+            );
+            $this->assertSame('PIC1: Patch reviewed', $GLOBALS['__editpatch_emails'][0]['subject']);
+            $this->assertStringContainsString(
+                'Your patch was reviewed, but it needs further changes.',
+                $GLOBALS['__editpatch_emails'][0]['msg']
+            );
+        } finally {
+            $GLOBALS['entityManager'] = $oldEntityManager;
+            unset($GLOBALS['patch']);
+            $this->tearDownEditPatchStubDirectory($oldWorkingDirectory, $stubDir);
+        }
+    }
+
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testEditPatchTaPlainCommentSendsGenericGroupNotification()
+    {
+        [$oldWorkingDirectory, $stubDir] = $this->setUpEditPatchStubDirectory();
+        $year = get_current_year();
+        $student = $this->createPageUser('ist9960', 'Alice Student', ROLE_STUDENT);
+        $ta = $this->createPageUser('ist9961', 'Taylor Assistant', ROLE_TA);
+        $ta->email = 'ta@example.com';
+
+        $group = $this->createEditPatchGroup($year, $student, $ta);
+        $patch = $this->createPatchStub(
+            group: $group,
+            submitter: $student,
+            status: \PatchStatus::Reviewed
+        );
+
+        $oldEntityManager = $this->mockEditPatchEntityManager($patch, $year);
+        $GLOBALS['patch'] = $patch;
+        $GLOBALS['__editpatch_emails'] = [];
+
+        try {
+            $this->setUpPageRuntime(
+                'editpatch',
+                $ta,
+                'POST',
+                ['id' => $patch->id],
+                [
+                    'comments' => [
+                        'text' => 'Please check the CI output.',
+                        'submit' => '',
+                    ],
+                ]
+            );
+
+            try {
+                $this->runPage('editpatch');
+                $this->fail('Expected page to redirect after adding a comment.');
+            } catch (PageRedirected) {
+            }
+
+            $this->assertSame('reviewed (not approved)', $patch->getStatus());
+            $this->assertSame('PIC1: new patch comment', $GLOBALS['__editpatch_emails'][0]['subject']);
+            $this->assertStringContainsString(
+                'Please check the CI output.',
+                $GLOBALS['__editpatch_emails'][0]['msg']
+            );
+        } finally {
+            $GLOBALS['entityManager'] = $oldEntityManager;
+            unset($GLOBALS['patch']);
+            $this->tearDownEditPatchStubDirectory($oldWorkingDirectory, $stubDir);
+        }
+    }
+
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testEditPatchFormUpdateAddsVideoChangeComment()
+    {
+        [$oldWorkingDirectory, $stubDir] = $this->setUpEditPatchStubDirectory();
+        $year = get_current_year();
+        $student = $this->createPageUser('ist9970', 'Alice Student', ROLE_STUDENT);
+        $prof = $this->createPageUser('ist9971', 'Professor Reviewer', ROLE_PROF);
+
+        $group = $this->createEditPatchGroup($year, $student, $prof);
+        $patch = $this->createPatchStub(
+            group: $group,
+            submitter: $student,
+            status: \PatchStatus::Reviewed,
+            videoUrl: 'https://example.org/old-video'
+        );
+
+        $oldEntityManager = $this->mockEditPatchEntityManager($patch, $year);
+
+        try {
+            $this->setUpPageRuntime(
+                'editpatch',
+                $student,
+                'POST',
+                ['id' => $patch->id],
+                [
+                    'form' => [
+                        'type' => (string)\PatchType::Feature->value,
+                        'video_url' => '',
+                        'submit' => '',
+                    ],
+                ]
+            );
+            $this->runPage('editpatch');
+
+            $this->assertSame('', $patch->video_url);
+            $this->assertSame('Database updated!', $GLOBALS['success_message']);
+            $this->assertCount(2, $patch->comments);
+            $this->assertSame(
+                'Video URL changed: https://example.org/old-video → ',
+                $patch->comments->last()->text
+            );
+        } finally {
+            $GLOBALS['entityManager'] = $oldEntityManager;
+            $this->tearDownEditPatchStubDirectory($oldWorkingDirectory, $stubDir);
+        }
+    }
+
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testEditPatchShowsUnavailableVideoMessageForInvalidStoredVideoUrl()
+    {
+        [$oldWorkingDirectory, $stubDir] = $this->setUpEditPatchStubDirectory();
+        $year = get_current_year();
+        $prof = $this->createPageUser('ist9980', 'Professor Reviewer', ROLE_PROF);
+        $student = $this->createPageUser('ist9981', 'Alice Student', ROLE_STUDENT);
+
+        $group = $this->createEditPatchGroup($year, $student, $prof);
+        $patch = $this->createPatchStub(
+            group: $group,
+            submitter: $student,
+            videoUrl: 'https://example.invalid/video'
+        );
+
+        $oldEntityManager = $this->mockEditPatchEntityManager($patch, $year);
+
+        try {
+            $this->setUpPageRuntime('editpatch', $prof, 'GET', ['id' => $patch->id]);
+            $this->runPage('editpatch');
+
+            $this->assertSame('Video no longer available', $GLOBALS['info_message']);
+        } finally {
+            $GLOBALS['entityManager'] = $oldEntityManager;
+            $this->tearDownEditPatchStubDirectory($oldWorkingDirectory, $stubDir);
+        }
+    }
+
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testEditPatchDisplaysUnavailablePatchInfoWhenPatchIsNoLongerValid()
+    {
+        [$oldWorkingDirectory, $stubDir] = $this->setUpEditPatchStubDirectory();
+        $year = get_current_year();
+        $prof = $this->createPageUser('ist9990', 'Professor Reviewer', ROLE_PROF);
+        $student = $this->createPageUser('ist9991', 'Alice Student', ROLE_STUDENT);
+
+        $group = $this->createEditPatchGroup($year, $student, $prof);
+        $patch = $this->createPatchStub(
+            group: $group,
+            submitter: $student,
+            valid: false
+        );
+
+        $oldEntityManager = $this->mockEditPatchEntityManager($patch, $year);
+
+        try {
+            $this->setUpPageRuntime('editpatch', $prof, 'GET', ['id' => $patch->id]);
+            $this->runPage('editpatch');
+
+            $this->assertSame('The patch is no longer available!', $GLOBALS['info_box']['title']);
+            $this->assertSame(
+                'https://github.com/owner/repo/tree/feature-branch',
+                $GLOBALS['info_box']['rows']['Patch']['url']
+            );
+        } finally {
+            $GLOBALS['entityManager'] = $oldEntityManager;
+            $this->tearDownEditPatchStubDirectory($oldWorkingDirectory, $stubDir);
+        }
+    }
+
+    private function setUpEditPatchStubDirectory(): array
+    {
+        $oldWorkingDirectory = getcwd();
+        $stubDir = sys_get_temp_dir() . '/pic1_editpatch_stubs_' . bin2hex(random_bytes(4));
+        mkdir($stubDir);
+
+        file_put_contents(
+            $stubDir . '/email.php',
+            <<<'PHP'
+<?php
+function email_ta($group, $subject, $msg, $html = false) {
+    $GLOBALS['__editpatch_emails'][] = [
+        'to' => $group->shift->prof?->email ?? '',
+        'subject' => $subject,
+        'msg' => $msg,
+        'html' => $html,
+    ];
+}
+function email_group($group, $subject, $msg, $html = false) {
+    $GLOBALS['__editpatch_emails'][] = [
+        'to' => $group->shift->prof?->email ?? '',
+        'subject' => $subject,
+        'msg' => $msg,
+        'html' => $html,
+    ];
+}
+PHP
+        );
+        file_put_contents(
+            $stubDir . '/review.php',
+            <<<'PHP'
+<?php
+function review_patch($project_name, $bug_fix, $patch, $patch_description, $issue_url, $issue_description, $coding_standard_url) {
+    return 'Stub AI review';
+}
+PHP
+        );
+
+        chdir($stubDir);
+
+        return [$oldWorkingDirectory, $stubDir];
+    }
+
+    private function tearDownEditPatchStubDirectory(string|false $oldWorkingDirectory, string $stubDir): void
+    {
+        if ($oldWorkingDirectory !== false) {
+            chdir($oldWorkingDirectory);
+        }
+        @unlink($stubDir . '/email.php');
+        @unlink($stubDir . '/review.php');
+        @rmdir($stubDir);
+    }
+
+    private function createEditPatchGroup(int $year, \User $student, \User $reviewer): \ProjGroup
+    {
+        $group = $this->createPageGroup(
+            51,
+            $year,
+            [$student],
+            prof: $reviewer,
+            groupId: 5100,
+            repository: 'github:owner/repo'
+        );
+        $group->url_proposal = 'https://example.org/issues/51';
+
+        return $group;
+    }
+
+    private function createPatchStub(
+        \ProjGroup $group,
+        \User $submitter,
+        \PatchStatus $status = \PatchStatus::Reviewed,
+        \PatchType $type = \PatchType::Feature,
+        bool $valid = true,
+        ?\PullRequest $pr = null,
+        string $patchUrl = 'https://github.com/owner/repo/tree/feature-branch',
+        string $videoUrl = '',
+        array $commits = [[
+            'username' => 'alice',
+            'name' => 'Alice Student',
+            'email' => 'alice@example.com',
+            'co-authored' => [],
+        ]]
+    ): \Patch {
+        $patch = new FakePatch(
+            valid: $valid,
+            patchOrigin: 'alice:repo:feature-branch',
+            patchCommits: $commits,
+            patchText: "diff --git a/file.php b/file.php\n",
+            branchHash: 'hash',
+            computedLinesAdded: 8,
+            computedLinesDeleted: 2,
+            computedFilesModified: 1,
+            patchUrl: $patchUrl,
+            commitUrlBase: 'https://github.com/owner/repo/commit/',
+            pullRequest: $pr
+        );
+
+        $patch->id = 9101;
+        $patch->group = $group;
+        $patch->status = $status;
+        $patch->type = $type;
+        $patch->video_url = $videoUrl;
+        $patch->hash = 'abc123';
+        $patch->lines_added = 8;
+        $patch->lines_deleted = 2;
+        $patch->files_modified = 1;
+        $patch->students->add($submitter);
+        $patch->comments->add(new \PatchComment($patch, 'Initial patch submission', $submitter));
+
+        return $patch;
+    }
+
+    private function createPullRequestStub(string $url): \PullRequest
+    {
+        return new FakePullRequest(
+            pullRequestUrl: $url,
+            branchUrl: 'https://github.com/owner/repo/tree/feature-branch',
+            pullRequestOrigin: 'alice:repo:feature-branch',
+            merger: 'reviewer',
+            mergedAt: new \DateTimeImmutable('2026-01-01 12:00:00'),
+            addedLines: 8,
+            deletedLines: 2,
+            modifiedFiles: 1
+        );
+    }
+
+    private function mockEditPatchEntityManager(\Patch $patch, int $year): mixed
+    {
+        $oldEntityManager = $GLOBALS['entityManager'] ?? null;
+        $GLOBALS['entityManager'] = new class($patch, $year) {
+            public int $flushCount = 0;
+
+            public function __construct(private \Patch $patch, private int $year) {}
+
+            public function find(string $entity, $id): mixed
+            {
+                if ($entity === 'Patch' && (int)$id === $this->patch->id) {
+                    return $this->patch;
+                }
+                if ($entity === 'Deadline') {
+                    $deadline = new \Deadline($this->year);
+                    $deadline->patch_submission = new \DateTimeImmutable('+1 day');
+                    return $deadline;
+                }
+
+                return null;
+            }
+
+            public function flush(): void
+            {
+                $this->flushCount++;
+            }
+        };
+
+        return $oldEntityManager;
+    }
+}

--- a/tests/Integration/Pages/FeaturePageTest.php
+++ b/tests/Integration/Pages/FeaturePageTest.php
@@ -1,0 +1,348 @@
+<?php
+
+namespace Tests\Integration\Pages;
+
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\HttpFoundation\Request;
+
+
+
+class FeaturePageTest extends PageTestCase
+{
+    public function testFeaturePageTerminatesWhenStudentHasNoGroup()
+    {
+        $year = get_current_year();
+        $deadline = new \Deadline($year);
+        $deadline->feature_selection = new \DateTimeImmutable('+1 day');
+
+        $oldEntityManager = $this->mockFeatureEntityManager($deadline);
+
+        try {
+            $this->setUpPageRuntime(
+                'feature',
+                $this->createPageUser('ist9700', 'No Group Student', ROLE_STUDENT)
+            );
+
+            $this->expectException(PageTerminated::class);
+            $this->expectExceptionMessage('Student is not in a group');
+            $this->runPage('feature');
+        } finally {
+            $GLOBALS['entityManager'] = $oldEntityManager;
+        }
+    }
+
+    public function testFeaturePageBuildsStudentUploadFormTableAndEvalBox()
+    {
+        $year = get_current_year();
+        $student = $this->createPageUser('ist9701', 'Feature Student', ROLE_STUDENT);
+        $group = $this->createGroup(17, $year, [$student]);
+        $group->url_proposal = 'https://example.org/issues/17';
+        $group->hash_proposal_file = 'featurehash17';
+        $group->allow_modifications_date = new \DateTimeImmutable('+2 days');
+
+        $deadline = new \Deadline($year);
+        $deadline->feature_selection = new \DateTimeImmutable('+1 day');
+
+        $oldEntityManager = $this->mockFeatureEntityManager($deadline);
+
+        try {
+            $this->setUpPageRuntime('feature', $student);
+            $this->runPage('feature');
+
+            $this->assertSame(
+                'You can submit this form multiple times until the deadline. Only the last submission will be considered.',
+                $GLOBALS['info_message']
+            );
+            $this->assertNotNull($GLOBALS['form']);
+            $this->assertTrue($GLOBALS['form']->has('url'));
+            $this->assertTrue($GLOBALS['form']->has('file'));
+            $this->assertTrue($GLOBALS['form']->has('submit'));
+            $this->assertSame(
+                'https://example.org/issues/17',
+                $GLOBALS['form']->get('url')->getData()
+            );
+
+            $this->assertSame(
+                [
+                    [
+                        'Group' => 17,
+                        'Issue URL' => [
+                            'label' => 'link',
+                            'url' => 'https://example.org/issues/17',
+                        ],
+                        'PDF' => [
+                            'label' => 'link',
+                            'url' => 'index.php?download=' . $group->id . '&page=feature',
+                        ],
+                    ],
+                ],
+                $GLOBALS['table']
+            );
+            $this->assertSame(
+                'index.php?download=' . $group->id . '&page=feature',
+                $GLOBALS['embed_file']
+            );
+            $this->assertCount(1, $GLOBALS['__page_test_eval_boxes']);
+            $this->assertSame('feature', $GLOBALS['__page_test_eval_boxes'][0]['page']);
+            $this->assertSame($group, $GLOBALS['__page_test_eval_boxes'][0]['group']);
+        } finally {
+            $GLOBALS['entityManager'] = $oldEntityManager;
+        }
+    }
+
+    public function testFeaturePageUploadsPdfAndStoresProposalUrl()
+    {
+        $year = get_current_year();
+        $student = $this->createPageUser('ist9702', 'Upload Student', ROLE_STUDENT);
+        $group = $this->createGroup(18, $year, [$student]);
+        $group->allow_modifications_date = new \DateTimeImmutable('+2 days');
+
+        $deadline = new \Deadline($year);
+        $deadline->feature_selection = new \DateTimeImmutable('+1 day');
+
+        $oldEntityManager = $this->mockFeatureEntityManager($deadline);
+        [$file, $tmpPath, $expectedHash] = $this->createUploadedPdf();
+        $uploadedPath = $this->uploadPath($expectedHash);
+
+        try {
+            $this->setUpPageRuntime(
+                'feature',
+                $student,
+                'POST',
+                [],
+                [
+                    'form' => [
+                        'url' => 'https://example.org/issues/18',
+                        'submit' => '',
+                    ],
+                ]
+            );
+
+            global $request;
+            $request = Request::create(
+                '/index.php?page=feature',
+                'POST',
+                $_POST,
+                [],
+                ['form' => ['file' => $file]]
+            );
+
+            $this->runPage('feature');
+
+            $this->assertSame('File uploaded successfully!', $GLOBALS['success_message']);
+            $this->assertSame('https://example.org/issues/18', $group->url_proposal);
+            $this->assertSame($expectedHash, $group->hash_proposal_file);
+            $this->assertFileExists($uploadedPath);
+            $this->assertSame(
+                'index.php?download=' . $group->id . '&page=feature',
+                $GLOBALS['embed_file']
+            );
+        } finally {
+            $GLOBALS['entityManager'] = $oldEntityManager;
+            if (file_exists($tmpPath)) {
+                @unlink($tmpPath);
+            }
+            if (file_exists($uploadedPath)) {
+                @unlink($uploadedPath);
+            }
+        }
+    }
+
+    public function testFeaturePageRejectsFeatureAlreadyChosenByAnotherGroup()
+    {
+        $year = get_current_year();
+        $student = $this->createPageUser('ist9703', 'Duplicate Student', ROLE_STUDENT);
+        $group = $this->createGroup(19, $year, [$student]);
+        $group->allow_modifications_date = new \DateTimeImmutable('+2 days');
+
+        $otherStudent = $this->createPageUser('ist9704', 'Other Student', ROLE_STUDENT);
+        $otherGroup = $this->createGroup(20, $year, [$otherStudent]);
+
+        $deadline = new \Deadline($year);
+        $deadline->feature_selection = new \DateTimeImmutable('+1 day');
+
+        $oldEntityManager = $this->mockFeatureEntityManager(
+            $deadline,
+            groupByUrl: $otherGroup
+        );
+        [$file, $tmpPath, $expectedHash] = $this->createUploadedPdf();
+        $uploadedPath = $this->uploadPath($expectedHash);
+
+        try {
+            $this->setUpPageRuntime(
+                'feature',
+                $student,
+                'POST',
+                [],
+                [
+                    'form' => [
+                        'url' => 'https://example.org/issues/19',
+                        'submit' => '',
+                    ],
+                ]
+            );
+
+            global $request;
+            $request = Request::create(
+                '/index.php?page=feature',
+                'POST',
+                $_POST,
+                [],
+                ['form' => ['file' => $file]]
+            );
+
+            $this->expectException(PageTerminated::class);
+            $this->expectExceptionMessage('This feature has been selected by another group already');
+            $this->runPage('feature');
+        } finally {
+            $GLOBALS['entityManager'] = $oldEntityManager;
+            if (file_exists($tmpPath)) {
+                @unlink($tmpPath);
+            }
+            if (file_exists($uploadedPath)) {
+                @unlink($uploadedPath);
+            }
+        }
+    }
+
+    public function testFeaturePageUsesFilteredGroupsForStaffAndEmbedsSinglePdf()
+    {
+        $year = get_current_year();
+        $prof = $this->createPageUser('ist9705', 'Professor Feature', ROLE_PROF);
+        $student = $this->createPageUser('ist9706', 'Grouped Student', ROLE_STUDENT);
+        $group = $this->createGroup(21, $year, [$student]);
+        $group->url_proposal = 'https://example.org/issues/21';
+        $group->hash_proposal_file = 'featurehash21';
+
+        $deadline = new \Deadline($year);
+        $deadline->feature_selection = new \DateTimeImmutable('-1 day');
+
+        $oldEntityManager = $this->mockFeatureEntityManager($deadline);
+        $GLOBALS['__page_test_filter_result'] = [$group];
+
+        try {
+            $this->setUpPageRuntime('feature', $prof);
+            $this->runPage('feature');
+
+            $this->assertNull($GLOBALS['form']);
+            $this->assertSame(
+                [
+                    [
+                        'Group' => 21,
+                        'Issue URL' => [
+                            'label' => 'link',
+                            'url' => 'https://example.org/issues/21',
+                        ],
+                        'PDF' => [
+                            'label' => 'link',
+                            'url' => 'index.php?download=' . $group->id . '&page=feature',
+                        ],
+                    ],
+                ],
+                $GLOBALS['table']
+            );
+            $this->assertSame(
+                'index.php?download=' . $group->id . '&page=feature',
+                $GLOBALS['embed_file']
+            );
+            $this->assertCount(1, $GLOBALS['__page_test_eval_boxes']);
+            $this->assertSame($group, $GLOBALS['__page_test_eval_boxes'][0]['group']);
+        } finally {
+            $GLOBALS['entityManager'] = $oldEntityManager;
+        }
+    }
+
+    private function createGroup(int $number, int $year, array $students): \ProjGroup
+    {
+        return $this->createPageGroup(
+            $number,
+            $year,
+            $students,
+            groupId: $number * 100,
+            shiftId: $number * 10
+        );
+    }
+
+    private function mockFeatureEntityManager(
+        \Deadline $deadline,
+        ?\ProjGroup $downloadGroup = null,
+        ?\ProjGroup $groupByUrl = null
+    ): mixed {
+        $oldEntityManager = $GLOBALS['entityManager'] ?? null;
+        $GLOBALS['entityManager'] = new class($deadline, $downloadGroup, $groupByUrl) {
+            public function __construct(
+                private \Deadline $deadline,
+                private ?\ProjGroup $downloadGroup,
+                private ?\ProjGroup $groupByUrl
+            ) {}
+
+            public function find(string $entity, $id): mixed
+            {
+                if ($entity === 'Deadline') {
+                    return $this->deadline;
+                }
+
+                if ($entity === 'ProjGroup') {
+                    return $this->downloadGroup;
+                }
+
+                return null;
+            }
+
+            public function createQueryBuilder(): object
+            {
+                return new class($this->groupByUrl) {
+                    private array $params = [];
+
+                    public function __construct(private ?\ProjGroup $groupByUrl) {}
+                    public function from($entity, $alias): self { return $this; }
+                    public function select($select): self { return $this; }
+                    public function where($where): self { return $this; }
+                    public function andWhere($where): self { return $this; }
+                    public function setParameter($name, $value): self
+                    {
+                        $this->params[$name] = $value;
+                        return $this;
+                    }
+                    public function getQuery(): self { return $this; }
+                    public function getOneOrNullResult(): ?\ProjGroup
+                    {
+                        if (($this->params['url'] ?? null) !== null) {
+                            return $this->groupByUrl;
+                        }
+
+                        return null;
+                    }
+                };
+            }
+
+            public function persist($obj): void
+            {
+            }
+
+            public function flush(): void
+            {
+            }
+        };
+
+        return $oldEntityManager;
+    }
+
+    private function createUploadedPdf(): array
+    {
+        $path = tempnam(sys_get_temp_dir(), 'pic1_feature_pdf_');
+        $contents = "%PDF-1.4\n1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n2 0 obj\n<< /Type /Pages /Count 0 >>\nendobj\ntrailer\n<< /Root 1 0 R >>\n%%EOF\n";
+        file_put_contents($path, $contents);
+
+        return [
+            new UploadedFile($path, 'proposal.pdf', 'application/pdf', null, true),
+            $path,
+            sha1($contents),
+        ];
+    }
+
+    private function uploadPath(string $hash): string
+    {
+        return dirname(__DIR__, 3) . '/uploads/' . $hash;
+    }
+}

--- a/tests/Integration/Pages/GradesPageTest.php
+++ b/tests/Integration/Pages/GradesPageTest.php
@@ -1,0 +1,310 @@
+<?php
+
+namespace Tests\Integration\Pages;
+
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+
+
+
+class GradesPageTest extends PageTestCase
+{
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testGradesPageTerminatesWhenFinalFormulaIsMissing()
+    {
+        $group = $this->createGroup(1001, get_current_year(), [
+            $this->createPageUser('ist9401', 'Alice Student', ROLE_STUDENT),
+        ]);
+        $student = $group->students->first();
+
+        $oldEntityManager = $this->mockGradesEntityManager(
+            milestones: [],
+            finalGrade: null,
+            grades: [],
+            usersById: [$student->id => $student]
+        );
+
+        try {
+            $this->setUpPageRuntime('grades', $student);
+
+            $this->expectException(PageTerminated::class);
+            $this->expectExceptionMessage('No final grade formula defined for year ' . get_current_year());
+            $this->runPage('grades');
+        } finally {
+            $GLOBALS['entityManager'] = $oldEntityManager;
+        }
+    }
+
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testGradesPageHandlesStudentWithoutGroupAndBinaryFormula()
+    {
+        $year = get_current_year();
+        $student = $this->createPageUser('ist9405', 'Lonely Student', ROLE_STUDENT);
+
+        $milestone = $this->createMilestone($year, 'M1', 'Milestone One', 'Code Quality', 200, 100);
+        $finalGrade = $this->createFinalGrade($year, 'M1+M2');
+
+        $oldEntityManager = $this->mockGradesEntityManager(
+            milestones: [$milestone],
+            finalGrade: $finalGrade,
+            grades: [],
+            usersById: []
+        );
+
+        try {
+            $this->setUpPageRuntime('grades', $student);
+            $this->runPage('grades');
+
+            $this->assertSame('Final Grade', $GLOBALS['display_formula']['title']);
+            $this->assertCount(3, $GLOBALS['display_formula']['items']);
+            $this->assertSame('M₁', $GLOBALS['display_formula']['items'][0]['var']);
+            $this->assertSame('+', $GLOBALS['display_formula']['items'][1]['var']);
+            $this->assertSame('M₂', $GLOBALS['display_formula']['items'][2]['var']);
+            $this->assertStringContainsString('Milestone One', $GLOBALS['display_formula']['items'][0]['title']);
+            $this->assertSame('', $GLOBALS['display_formula']['items'][2]['title']);
+            $this->assertNull($GLOBALS['table']);
+            $this->assertNull($GLOBALS['bottom_links']);
+            $this->assertNull($GLOBALS['plots']);
+            $this->assertSame([], $GLOBALS['__page_test_eval_boxes'] ?? []);
+        } finally {
+            $GLOBALS['entityManager'] = $oldEntityManager;
+        }
+    }
+
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testGradesPageBuildsStudentTableAndFormulaDisplay()
+    {
+        $year = get_current_year();
+        $student = $this->createPageUser('ist9402', 'Alice Student', ROLE_STUDENT);
+        $group = $this->createGroup(1001, $year, [$student]);
+
+        $milestone = $this->createMilestone($year, 'M1', 'Milestone One', 'Code Quality', 200, 100);
+        $grade = $this->createGrade($student, $milestone, 80, lateDays: 0);
+        $finalGrade = $this->createFinalGrade($year, 'M1');
+
+        $oldEntityManager = $this->mockGradesEntityManager(
+            milestones: [$milestone],
+            finalGrade: $finalGrade,
+            grades: [$grade],
+            usersById: [$student->id => $student]
+        );
+
+        try {
+            $this->setUpPageRuntime('grades', $student);
+            $this->runPage('grades');
+
+            $this->assertCount(1, $GLOBALS['__page_test_eval_boxes']);
+            $this->assertSame($group, $GLOBALS['__page_test_eval_boxes'][0]['group']);
+
+            $this->assertSame('Final Grade', $GLOBALS['display_formula']['title']);
+            $this->assertSame('M₁', $GLOBALS['display_formula']['items'][0]['var']);
+            $this->assertSame('indigo', $GLOBALS['display_formula']['items'][0]['color']);
+            $this->assertStringContainsString('Milestone One', $GLOBALS['display_formula']['items'][0]['title']);
+            $this->assertStringContainsString('Code Quality: 20.00', $GLOBALS['display_formula']['items'][0]['title']);
+
+            $this->assertCount(1, $GLOBALS['table']);
+            $row = $GLOBALS['table'][0];
+            $this->assertSame('ist9402', $row['id']);
+            $this->assertSame('Alice Student', $row['name']);
+            $this->assertTrue($row['_large_table']);
+            $this->assertSame('16.00', $row['M1']['text']);
+            $this->assertStringContainsString('Milestone One', $row['M1']['tooltip']);
+            $this->assertStringContainsString('Code Quality: 16.00', $row['M1']['tooltip']);
+            $this->assertSame(16, $row['Final']);
+            $this->assertNull($GLOBALS['plots']);
+            $this->assertNull($GLOBALS['bottom_links']);
+        } finally {
+            $GLOBALS['entityManager'] = $oldEntityManager;
+        }
+    }
+
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testGradesPageBuildsProfessorPlotsAndDownloadLinks()
+    {
+        $year = get_current_year();
+        $student1 = $this->createPageUser('ist9403', 'Alice Student', ROLE_STUDENT);
+        $student2 = $this->createPageUser('ist9404', 'Bob Student', ROLE_STUDENT);
+        $group1 = $this->createGroup(1001, $year, [$student1]);
+        $group2 = $this->createGroup(2001, $year, [$student2]);
+
+        $milestone = $this->createMilestone($year, 'M1', 'Milestone One', 'Code Quality', 200, 100);
+        $grade1 = $this->createGrade($student1, $milestone, 80, lateDays: 0);
+        $grade2 = $this->createGrade($student2, $milestone, 50, lateDays: 6);
+        $finalGrade = $this->createFinalGrade($year, 'M1');
+
+        $oldEntityManager = $this->mockGradesEntityManager(
+            milestones: [$milestone],
+            finalGrade: $finalGrade,
+            grades: [$grade1, $grade2],
+            usersById: [
+                $student1->id => $student1,
+                $student2->id => $student2,
+            ]
+        );
+
+        $GLOBALS['__page_test_filter_result'] = [$group1, $group2];
+
+        try {
+            $this->setUpPageRuntime(
+                'grades',
+                $this->createPageUser('ist9400', 'Professor Admin', ROLE_PROF)
+            );
+            $this->runPage('grades');
+
+            $this->assertCount(2, $GLOBALS['table']);
+            $this->assertSame(16, $GLOBALS['table'][0]['Final']);
+            $this->assertSame(5, $GLOBALS['table'][1]['Final']);
+
+            $this->assertNotNull($GLOBALS['plots']);
+            $this->assertSame(1, $GLOBALS['plots']['Overall'][16]);
+            $this->assertSame(1, $GLOBALS['plots']['Overall'][5]);
+            $this->assertSame(1, $GLOBALS['plots']['Group 1'][16]);
+            $this->assertSame(1, $GLOBALS['plots']['Group 2'][5]);
+
+            $this->assertCount(2, $GLOBALS['bottom_links']);
+            $this->assertSame('Download grades of group 1', $GLOBALS['bottom_links'][0]['label']);
+            $this->assertSame(
+                'index.php?download=1&all_shifts=1&page=grades',
+                $GLOBALS['bottom_links'][0]['url']
+            );
+            $this->assertSame('Download grades of group 2', $GLOBALS['bottom_links'][1]['label']);
+        } finally {
+            $GLOBALS['entityManager'] = $oldEntityManager;
+        }
+    }
+
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testGradesPageHelperRejectsUnknownNodeType()
+    {
+        $year = get_current_year();
+        $student = $this->createPageUser('ist9406', 'Helper Student', ROLE_STUDENT);
+
+        $milestone = $this->createMilestone($year, 'M1', 'Milestone One', 'Code Quality', 200, 100);
+        $finalGrade = $this->createFinalGrade($year, 'M1');
+
+        $oldEntityManager = $this->mockGradesEntityManager(
+            milestones: [$milestone],
+            finalGrade: $finalGrade,
+            grades: [],
+            usersById: []
+        );
+
+        try {
+            $this->setUpPageRuntime('grades', $student);
+            $this->runPage('grades');
+
+            $this->expectException(\AssertionError::class);
+            gen_formula_data(new \Symfony\Component\ExpressionLanguage\Node\Node());
+        } finally {
+            $GLOBALS['entityManager'] = $oldEntityManager;
+        }
+    }
+
+    private function createGroup(int $number, int $year, array $students): \ProjGroup
+    {
+        return $this->createPageGroup($number, $year, $students, groupId: $number);
+    }
+
+    private function createMilestone(
+        int $year,
+        string $name,
+        string $description,
+        string $field1,
+        int $points1,
+        int $range1
+    ): \Milestone {
+        $milestone = new \Milestone($year, $name);
+        $milestone->description = $description;
+        $milestone->field1 = $field1;
+        $milestone->points1 = $points1;
+        $milestone->range1 = $range1;
+        return $milestone;
+    }
+
+    private function createGrade(\User $user, \Milestone $milestone, int $field1, int $lateDays): \Grade
+    {
+        $grade = new \Grade();
+        $grade->user = $user;
+        $grade->milestone = $milestone;
+        $grade->field1 = $field1;
+        $grade->field2 = null;
+        $grade->field3 = null;
+        $grade->field4 = null;
+        $grade->late_days = $lateDays;
+        return $grade;
+    }
+
+    private function createFinalGrade(int $year, string $formula): \FinalGrade
+    {
+        $finalGrade = new \FinalGrade();
+        $finalGrade->year = $year;
+        $finalGrade->formula = $formula;
+        return $finalGrade;
+    }
+
+    private function mockGradesEntityManager(
+        array $milestones,
+        ?\FinalGrade $finalGrade,
+        array $grades,
+        array $usersById
+    ): mixed {
+        $oldEntityManager = $GLOBALS['entityManager'] ?? null;
+        $GLOBALS['entityManager'] = new class($milestones, $finalGrade, $grades, $usersById) {
+            public function __construct(
+                private array $milestones,
+                private ?\FinalGrade $finalGrade,
+                private array $grades,
+                private array $usersById
+            ) {}
+
+            public function find(string $entity, $id): mixed
+            {
+                if ($entity === 'FinalGrade') {
+                    return $this->finalGrade;
+                }
+
+                if ($entity === 'User') {
+                    return $this->usersById[$id] ?? null;
+                }
+
+                return null;
+            }
+
+            public function getRepository(string $entity): object
+            {
+                if ($entity === 'Milestone') {
+                    return new class($this->milestones) {
+                        public function __construct(private array $milestones) {}
+                        public function findByYear($year): array
+                        {
+                            return $this->milestones;
+                        }
+                    };
+                }
+
+                throw new \RuntimeException("Unexpected repository lookup: $entity");
+            }
+
+            public function createQueryBuilder(): object
+            {
+                return new class($this->grades) {
+                    public function __construct(private array $grades) {}
+                    public function from($entity, $alias): self { return $this; }
+                    public function select($select): self { return $this; }
+                    public function join($join, $alias): self { return $this; }
+                    public function where($where): self { return $this; }
+                    public function setParameter($name, $value): self { return $this; }
+                    public function getQuery(): self { return $this; }
+                    public function getResult(): array { return $this->grades; }
+                };
+            }
+        };
+
+        return $oldEntityManager;
+    }
+}

--- a/tests/Integration/Pages/GradingPageTest.php
+++ b/tests/Integration/Pages/GradingPageTest.php
@@ -1,0 +1,423 @@
+<?php
+
+namespace Tests\Integration\Pages;
+
+
+
+
+class GradingPageTest extends PageTestCase
+{
+    public function testGradingPageAddsMilestone()
+    {
+        $year = get_current_year();
+        $oldEntityManager = $this->mockGradingEntityManager(
+            milestonesByYear: [$year => []],
+            milestoneYears: [],
+            finalGradesByYear: [],
+            milestonesById: []
+        );
+        $GLOBALS['__page_test_filter_result'] = $year;
+
+        try {
+            $prof = $this->createPageUser('ist9930', 'Professor Grading', ROLE_PROF);
+            $this->setUpPageRuntime(
+                'grading',
+                $prof,
+                'POST',
+                [],
+                [
+                    'add_milestone' => [
+                        'name' => 'Milestone X',
+                        'submit' => '',
+                    ],
+                ]
+            );
+            $this->runPage('grading');
+
+            $saved = $GLOBALS['entityManager']->saved[0] ?? null;
+            $this->assertInstanceOf(\Milestone::class, $saved);
+            $this->assertSame($year, $saved->year);
+            $this->assertSame('Milestone X', $saved->name);
+            $this->assertCount(1, $GLOBALS['entityManager']->saved);
+            $this->assertSame(1, $GLOBALS['entityManager']->flushCount);
+        } finally {
+            $GLOBALS['entityManager'] = $oldEntityManager;
+        }
+    }
+
+    public function testGradingPageCopiesMilestonesAndFinalFormulaFromSourceYear()
+    {
+        $year = get_current_year();
+        $sourceYear = $year - 1;
+
+        $sourceMilestone = new \Milestone($sourceYear, 'M1');
+        $sourceMilestone->description = 'Imported milestone';
+        $sourceMilestone->field1 = 'Code Quality';
+        $sourceMilestone->points1 = 200;
+        $sourceMilestone->range1 = 100;
+
+        $sourceFinal = new \FinalGrade();
+        $sourceFinal->year = $sourceYear;
+        $sourceFinal->formula = 'M1';
+
+        $oldEntityManager = $this->mockGradingEntityManager(
+            milestonesByYear: [
+                $year => [],
+                $sourceYear => [$sourceMilestone],
+            ],
+            milestoneYears: [['year' => $sourceYear]],
+            finalGradesByYear: [$sourceYear => $sourceFinal],
+            milestonesById: []
+        );
+        $GLOBALS['__page_test_filter_result'] = $year;
+
+        try {
+            $prof = $this->createPageUser('ist9931', 'Professor Copy', ROLE_PROF);
+            $this->setUpPageRuntime(
+                'grading',
+                $prof,
+                'POST',
+                [],
+                [
+                    'copy' => [
+                        'source_year' => (string)$sourceYear,
+                        'copy' => '',
+                    ],
+                ]
+            );
+            $this->runPage('grading');
+
+            $this->assertSame(
+                "Grading copied successfully from year $sourceYear.",
+                $GLOBALS['success_message']
+            );
+            $this->assertCount(2, $GLOBALS['entityManager']->saved);
+            $this->assertInstanceOf(\Milestone::class, $GLOBALS['entityManager']->saved[0]);
+            $this->assertSame($year, $GLOBALS['entityManager']->saved[0]->year);
+            $this->assertSame('M1', $GLOBALS['entityManager']->saved[0]->name);
+            $this->assertSame('Imported milestone', $GLOBALS['entityManager']->saved[0]->description);
+            $this->assertInstanceOf(\FinalGrade::class, $GLOBALS['entityManager']->saved[1]);
+            $this->assertSame($year, $GLOBALS['entityManager']->saved[1]->year);
+            $this->assertSame('M1', $GLOBALS['entityManager']->saved[1]->formula);
+            $this->assertSame(1, $GLOBALS['entityManager']->flushCount);
+        } finally {
+            $GLOBALS['entityManager'] = $oldEntityManager;
+        }
+    }
+
+    public function testGradingPageBuildsFinalGradeFormAndTerminates()
+    {
+        $year = get_current_year();
+        $finalGrade = new \FinalGrade();
+        $finalGrade->year = $year;
+        $finalGrade->formula = 'M1+M2';
+
+        $oldEntityManager = $this->mockGradingEntityManager(
+            milestonesByYear: [$year => []],
+            milestoneYears: [],
+            finalGradesByYear: [$year => $finalGrade],
+            milestonesById: []
+        );
+        $GLOBALS['__page_test_filter_result'] = $year;
+
+        try {
+            $prof = $this->createPageUser('ist9932', 'Professor Final', ROLE_PROF);
+            $this->setUpPageRuntime('grading', $prof, 'GET', ['final' => 1]);
+
+            try {
+                $this->runPage('grading');
+                $this->fail('Expected grading page to terminate after building final grade form.');
+            } catch (PageTerminated) {
+            }
+
+            $this->assertNotNull($GLOBALS['form']);
+            $this->assertTrue($GLOBALS['form']->has('final'));
+            $this->assertTrue($GLOBALS['form']->has('formula'));
+            $this->assertTrue($GLOBALS['form']->has('submit'));
+            $this->assertSame('M1+M2', $GLOBALS['form']->get('formula')->getData());
+        } finally {
+            $GLOBALS['entityManager'] = $oldEntityManager;
+        }
+    }
+
+    public function testGradingPageSavesFinalGradeFormulaFromFinalFormSubmission()
+    {
+        $year = get_current_year();
+        $oldEntityManager = $this->mockGradingEntityManager(
+            milestonesByYear: [$year => []],
+            milestoneYears: [],
+            finalGradesByYear: [],
+            milestonesById: []
+        );
+        $GLOBALS['__page_test_filter_result'] = $year;
+
+        try {
+            $prof = $this->createPageUser('ist9933', 'Professor Final Save', ROLE_PROF);
+            $this->setUpPageRuntime(
+                'grading',
+                $prof,
+                'POST',
+                ['final' => 1],
+                [
+                    'form' => [
+                        'final' => '1',
+                        'formula' => 'M1+M2',
+                        'submit' => '',
+                    ],
+                ]
+            );
+
+            set_error_handler(static function (int $severity, string $message): bool {
+                return str_contains($message, 'Undefined variable $data');
+            });
+
+            try {
+                try {
+                    $this->runPage('grading');
+                    $this->fail('Expected grading page to terminate after saving final grade.');
+                } catch (PageTerminated) {
+                }
+            } finally {
+                restore_error_handler();
+            }
+
+            $saved = $GLOBALS['entityManager']->saved[0] ?? null;
+            $this->assertInstanceOf(\FinalGrade::class, $saved);
+            $this->assertSame($year, $saved->year);
+            $this->assertSame('M1+M2', $saved->formula);
+            $this->assertCount(1, $GLOBALS['entityManager']->saved);
+            $this->assertSame(1, $GLOBALS['entityManager']->flushCount);
+        } finally {
+            $GLOBALS['entityManager'] = $oldEntityManager;
+        }
+    }
+
+    public function testGradingPageEditsMilestoneAndBuildsMilestonesTable()
+    {
+        $year = get_current_year();
+        $milestone = new \Milestone($year, 'M1');
+        $milestone->id = 901;
+        $milestone->description = 'Original description';
+        $milestone->field1 = 'Code Quality';
+        $milestone->points1 = 100;
+        $milestone->range1 = 50;
+
+        $oldEntityManager = $this->mockGradingEntityManager(
+            milestonesByYear: [$year => [$milestone]],
+            milestoneYears: [],
+            finalGradesByYear: [],
+            milestonesById: [$milestone->id => $milestone]
+        );
+        $GLOBALS['__page_test_filter_result'] = $year;
+
+        try {
+            $prof = $this->createPageUser('ist9934', 'Professor Edit', ROLE_PROF);
+            $this->setUpPageRuntime(
+                'grading',
+                $prof,
+                'POST',
+                ['id' => $milestone->id],
+                [
+                    'form' => [
+                        'id' => '999',
+                        'year' => '1999',
+                        'name' => 'M1 Updated',
+                        'description' => 'Updated description',
+                        'page' => 'grades',
+                        'field1' => 'Testing',
+                        'points1' => '200',
+                        'range1' => '100',
+                        'field2' => '',
+                        'points2' => '0',
+                        'range2' => '0',
+                        'field3' => '',
+                        'points3' => '0',
+                        'range3' => '0',
+                        'field4' => '',
+                        'points4' => '0',
+                        'range4' => '0',
+                        'submit' => '',
+                    ],
+                ]
+            );
+            $this->runPage('grading');
+
+            $this->assertSame(901, $milestone->id);
+            $this->assertSame($year, $milestone->year);
+            $this->assertSame('M1 Updated', $milestone->name);
+            $this->assertSame('Updated description', $milestone->description);
+            $this->assertSame('grades', $milestone->page);
+            $this->assertSame('Testing', $milestone->field1);
+            $this->assertSame(200, $milestone->points1);
+            $this->assertSame(100, $milestone->range1);
+            $this->assertSame('Database updated!', $GLOBALS['success_message']);
+
+            $this->assertCount(1, $GLOBALS['table']);
+            $row = $GLOBALS['table'][0];
+            $this->assertSame('M1 Updated', $row['name']['label']);
+            $this->assertSame('index.php?id=901&page=grading', $row['name']['url']);
+            $this->assertTrue($row['_large_table']);
+            $this->assertSame('Updated description', $row['description']);
+            $this->assertSame('grades', $row['page']);
+            $this->assertSame('Testing', $row['field1']);
+            $this->assertSame(200, $row['points1']);
+            $this->assertSame(100, $row['range1']);
+        } finally {
+            $GLOBALS['entityManager'] = $oldEntityManager;
+        }
+    }
+
+    public function testGradingPageRejectsInvalidMilestoneId()
+    {
+        $result = $this->runGradingScriptWithInvalidMilestone();
+
+        $this->assertSame(0, $result['exit_code']);
+        $this->assertSame('Invalid milestone', $result['output']);
+    }
+
+    private function mockGradingEntityManager(
+        array $milestonesByYear,
+        array $milestoneYears,
+        array $finalGradesByYear,
+        array $milestonesById
+    ): mixed {
+        $oldEntityManager = $GLOBALS['entityManager'] ?? null;
+        $GLOBALS['entityManager'] = new class($milestonesByYear, $milestoneYears, $finalGradesByYear, $milestonesById) {
+            public array $saved = [];
+            public int $flushCount = 0;
+
+            public function __construct(
+                private array $milestonesByYear,
+                private array $milestoneYears,
+                private array $finalGradesByYear,
+                private array $milestonesById
+            ) {}
+
+            public function find(string $entity, $id): mixed
+            {
+                if ($entity === 'FinalGrade') {
+                    return $this->finalGradesByYear[$id] ?? null;
+                }
+                if ($entity === 'Milestone') {
+                    return $this->milestonesById[$id] ?? null;
+                }
+
+                return null;
+            }
+
+            public function getRepository(string $entity): object
+            {
+                if ($entity === 'Milestone') {
+                    return new class($this->milestonesByYear) {
+                        public function __construct(private array $milestonesByYear) {}
+
+                        public function findByYear($year, $order = null): array
+                        {
+                            return $this->milestonesByYear[$year] ?? [];
+                        }
+                    };
+                }
+
+                throw new \RuntimeException("Unexpected repository lookup: $entity");
+            }
+
+            public function createQueryBuilder(): object
+            {
+                return new class($this->milestoneYears) {
+                    public function __construct(private array $milestoneYears) {}
+                    public function from($entity, $alias): self { return $this; }
+                    public function select($select): self { return $this; }
+                    public function distinct(): self { return $this; }
+                    public function orderBy($field, $direction = null): self { return $this; }
+                    public function getQuery(): self { return $this; }
+                    public function getArrayResult(): array { return $this->milestoneYears; }
+                };
+            }
+
+            public function persist($obj): void
+            {
+                $this->saved[] = $obj;
+            }
+
+            public function flush(): void
+            {
+                $this->flushCount++;
+            }
+        };
+
+        return $oldEntityManager;
+    }
+
+    private function runGradingScriptWithInvalidMilestone(): array
+    {
+        $script = sys_get_temp_dir() . '/pic1_grading_' . bin2hex(random_bytes(4)) . '.php';
+        $bootstrap = var_export(dirname(__DIR__, 3) . '/tests/bootstrap.php', true);
+        $pageTestCase = var_export(dirname(__DIR__) . '/Pages/PageTestCase.php', true);
+        $page = var_export(dirname(__DIR__, 3) . '/pages/grading.php', true);
+        $year = get_current_year();
+
+        $code = <<<PHP
+<?php
+require $bootstrap;
+require $pageTestCase;
+\$_SERVER['HTTP_HOST'] = 'localhost';
+\$_GET = ['page' => 'grading', 'id' => 999];
+\$_POST = [];
+\$_REQUEST = \$_GET;
+\$GLOBALS['__page_test_filter_result'] = $year;
+\$request = Symfony\Component\HttpFoundation\Request::create('/index.php?page=grading&id=999', 'GET', \$_GET);
+\$formFactory = Symfony\Component\Form\Forms::createFormFactoryBuilder()
+    ->addExtension(new Symfony\Component\Form\Extension\HttpFoundation\HttpFoundationExtension())
+    ->getFormFactory();
+\$GLOBALS['page'] = 'grading';
+\$GLOBALS['entityManager'] = new class {
+    public function find(string \$entity, \$id): mixed
+    {
+        return null;
+    }
+
+    public function getRepository(string \$entity): object
+    {
+        if (\$entity === 'Milestone') {
+            return new class {
+                public function findByYear(\$year, \$order = null): array
+                {
+                    return [];
+                }
+            };
+        }
+
+        throw new RuntimeException('Unexpected repository lookup');
+    }
+
+    public function createQueryBuilder(): object
+    {
+        return new class {
+            public function from(\$entity, \$alias): self { return \$this; }
+            public function select(\$select): self { return \$this; }
+            public function distinct(): self { return \$this; }
+            public function orderBy(\$field, \$direction = null): self { return \$this; }
+            public function getQuery(): self { return \$this; }
+            public function getArrayResult(): array { return []; }
+        };
+    }
+};
+require $page;
+PHP;
+
+        file_put_contents($script, $code);
+
+        try {
+            $output = [];
+            $exitCode = 0;
+            exec(escapeshellarg(PHP_BINARY) . ' ' . escapeshellarg($script), $output, $exitCode);
+
+            return [
+                'output' => implode("\n", $output),
+                'exit_code' => $exitCode,
+            ];
+        } finally {
+            @unlink($script);
+        }
+    }
+}

--- a/tests/Integration/Pages/ImpersonatePageTest.php
+++ b/tests/Integration/Pages/ImpersonatePageTest.php
@@ -1,0 +1,247 @@
+<?php
+
+namespace Tests\Integration\Pages;
+
+
+
+class ImpersonatePageTest extends PageTestCase
+{
+    public function testImpersonatePageBuildsDummyAndUserLists()
+    {
+        $user = $this->createPageUser('ist9950', 'Real User', ROLE_STUDENT);
+        $oldEntityManager = $this->mockImpersonateEntityManager([$user]);
+
+        try {
+            $sudo = $this->createPageUser('ist9951', 'Sudo User', ROLE_SUDO);
+            $this->setUpPageRuntime('impersonate', $sudo);
+            $this->runPage('impersonate');
+
+            $this->assertCount(3, $GLOBALS['lists']['Switch to dummy']);
+            $this->assertSame('Professor', $GLOBALS['lists']['Switch to dummy'][0]['label']);
+            $this->assertSame('index.php?newrole=1&page=impersonate', $GLOBALS['lists']['Switch to dummy'][0]['url']);
+            $this->assertSame('TA', $GLOBALS['lists']['Switch to dummy'][1]['label']);
+            $this->assertSame('index.php?newrole=2&page=impersonate', $GLOBALS['lists']['Switch to dummy'][1]['url']);
+            $this->assertSame('Student', $GLOBALS['lists']['Switch to dummy'][2]['label']);
+            $this->assertSame('index.php?newrole=3&page=impersonate', $GLOBALS['lists']['Switch to dummy'][2]['url']);
+            $this->assertCount(1, $GLOBALS['lists']['Impersonate real users']);
+            $this->assertSame(
+                'ist9950: Real User (Student)',
+                $GLOBALS['lists']['Impersonate real users'][0]['label']
+            );
+            $this->assertSame(
+                'index.php?username=ist9950&page=impersonate',
+                $GLOBALS['lists']['Impersonate real users'][0]['url']
+            );
+        } finally {
+            $GLOBALS['entityManager'] = $oldEntityManager;
+        }
+    }
+
+    public function testImpersonatePageSwitchesToRequestedUser()
+    {
+        $target = $this->createPageUser('ist9952', 'Chosen User', ROLE_TA);
+        $oldEntityManager = $this->mockImpersonateEntityManager([$target]);
+
+        try {
+            $sudo = $this->createPageUser('ist9953', 'Sudo User', ROLE_SUDO);
+            $this->setUpPageRuntime('impersonate', $sudo, 'GET', ['username' => $target->id]);
+            $this->runPage('impersonate');
+
+            $this->assertSame($target, $GLOBALS['__page_test_user']);
+            $this->assertCount(1, $GLOBALS['__page_test_auth_set_user']);
+            $this->assertSame($target, $GLOBALS['__page_test_auth_set_user'][0]);
+        } finally {
+            $GLOBALS['entityManager'] = $oldEntityManager;
+        }
+    }
+
+    public function testImpersonatePageSwitchesToRequestedDummyRole()
+    {
+        $oldEntityManager = $this->mockImpersonateEntityManager([]);
+        $_SESSION = [];
+
+        try {
+            $sudo = $this->createPageUser('ist9954', 'Sudo User', ROLE_SUDO);
+            $this->setUpPageRuntime('impersonate', $sudo, 'GET', ['newrole' => ROLE_TA]);
+            $this->runPage('impersonate');
+
+            $saved = $GLOBALS['entityManager']->persisted[0] ?? null;
+            $this->assertInstanceOf(\User::class, $saved);
+            $this->assertSame('ist00002', $_SESSION['username']);
+            $this->assertSame('ist00002', $saved->id);
+            $this->assertSame('Dummy 2', $saved->name);
+            $this->assertSame(ROLE_TA, $saved->role);
+            $this->assertSame('ist00002@example.org', $saved->email);
+            $this->assertSame(
+                'https://api.dicebear.com/9.x/notionists-neutral/svg?seed=Adrian&lips=variant17',
+                $saved->photo
+            );
+            $this->assertTrue($saved->isDummy());
+            $this->assertCount(1, $GLOBALS['entityManager']->persisted);
+            $this->assertSame(1, $GLOBALS['entityManager']->flushCount);
+            $this->assertCount(1, $GLOBALS['__page_test_auth_set_user']);
+            $this->assertSame($saved, $GLOBALS['__page_test_auth_set_user'][0]);
+            $this->assertSame($saved, $GLOBALS['__page_test_user']);
+        } finally {
+            $GLOBALS['entityManager'] = $oldEntityManager;
+        }
+    }
+
+    public function testImpersonatePageReusesExistingDummyUserWhenRoleAlreadyExists()
+    {
+        $existing = new \User(
+            'ist00001',
+            'Dummy 1',
+            'ist00001@example.org',
+            'https://api.dicebear.com/9.x/notionists-neutral/svg?seed=Ryker&lips=variant17',
+            ROLE_PROF,
+            true
+        );
+        $oldEntityManager = $this->mockImpersonateEntityManager([$existing]);
+        $_SESSION = [];
+
+        try {
+            $sudo = $this->createPageUser('ist9955', 'Sudo User', ROLE_SUDO);
+            $this->setUpPageRuntime('impersonate', $sudo, 'GET', ['newrole' => ROLE_PROF]);
+            $this->runPage('impersonate');
+
+            $this->assertSame('ist00001', $_SESSION['username']);
+            $this->assertSame([], $GLOBALS['entityManager']->persisted);
+            $this->assertSame(0, $GLOBALS['entityManager']->flushCount);
+            $this->assertCount(1, $GLOBALS['__page_test_auth_set_user']);
+            $this->assertSame($existing, $GLOBALS['__page_test_auth_set_user'][0]);
+            $this->assertSame($existing, $GLOBALS['__page_test_user']);
+        } finally {
+            $GLOBALS['entityManager'] = $oldEntityManager;
+        }
+    }
+
+    public function testImpersonatePageRejectsUnknownUsername()
+    {
+        $result = $this->runImpersonateScript(['username' => 'missing']);
+
+        $this->assertSame(0, $result['exit_code']);
+        $this->assertSame('Unknown user', $result['output']);
+    }
+
+    public function testImpersonatePageRejectsInvalidRole()
+    {
+        $result = $this->runImpersonateScript(['newrole' => 99]);
+
+        $this->assertSame(0, $result['exit_code']);
+        $this->assertSame('Unknown role', $result['output']);
+    }
+
+    private function mockImpersonateEntityManager(array $users): mixed
+    {
+        $oldEntityManager = $GLOBALS['entityManager'] ?? null;
+        $usersById = [];
+        foreach ($users as $user) {
+            $usersById[$user->id] = $user;
+        }
+
+        $GLOBALS['entityManager'] = new class($users, $usersById) {
+            public array $persisted = [];
+            public int $flushCount = 0;
+
+            public function __construct(private array $users, private array $usersById) {}
+
+            public function find(string $entity, $id): mixed
+            {
+                if ($entity === 'User') {
+                    return $this->usersById[$id] ?? null;
+                }
+
+                return null;
+            }
+
+            public function getRepository(string $entity): object
+            {
+                if ($entity === 'User') {
+                    return new class($this->users) {
+                        public function __construct(private array $users) {}
+
+                        public function findBy(array $criteria, array $order): array
+                        {
+                            return $this->users;
+                        }
+                    };
+                }
+
+                throw new \RuntimeException("Unexpected repository lookup: $entity");
+            }
+
+            public function persist($obj): void
+            {
+                $this->persisted[] = $obj;
+                if ($obj instanceof \User) {
+                    $this->usersById[$obj->id] = $obj;
+                    $this->users[] = $obj;
+                }
+            }
+
+            public function flush(): void
+            {
+                $this->flushCount++;
+            }
+        };
+
+        return $oldEntityManager;
+    }
+
+    private function runImpersonateScript(array $query): array
+    {
+        $script = sys_get_temp_dir() . '/pic1_impersonate_' . bin2hex(random_bytes(4)) . '.php';
+        $bootstrap = var_export(dirname(__DIR__, 3) . '/tests/bootstrap.php', true);
+        $pageTestCase = var_export(dirname(__DIR__) . '/Pages/PageTestCase.php', true);
+        $page = var_export(dirname(__DIR__, 3) . '/pages/impersonate.php', true);
+        $queryExport = var_export(['page' => 'impersonate'] + $query, true);
+
+        $code = <<<PHP
+<?php
+require $bootstrap;
+require $pageTestCase;
+\$_SERVER['HTTP_HOST'] = 'localhost';
+\$_GET = $queryExport;
+\$_POST = [];
+\$_REQUEST = \$_GET;
+\$_SESSION = [];
+\$GLOBALS['entityManager'] = new class {
+    public function find(string \$entity, \$id): mixed
+    {
+        return null;
+    }
+
+    public function getRepository(string \$entity): object
+    {
+        if (\$entity === 'User') {
+            return new class {
+                public function findBy(array \$criteria, array \$order): array
+                {
+                    return [];
+                }
+            };
+        }
+
+        throw new RuntimeException('Unexpected repository lookup');
+    }
+};
+require $page;
+PHP;
+
+        file_put_contents($script, $code);
+
+        try {
+            $output = [];
+            $exitCode = 0;
+            exec(escapeshellarg(PHP_BINARY) . ' ' . escapeshellarg($script), $output, $exitCode);
+
+            return [
+                'output' => implode("\n", $output),
+                'exit_code' => $exitCode,
+            ];
+        } finally {
+            @unlink($script);
+        }
+    }
+}

--- a/tests/Integration/Pages/ListProjectPageTest.php
+++ b/tests/Integration/Pages/ListProjectPageTest.php
@@ -1,0 +1,405 @@
+<?php
+
+namespace Tests\Integration\Pages;
+
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+
+
+class ListProjectPageTest extends PageTestCase
+{
+    public function testListProjectRequiresId()
+    {
+        $result = $this->runListProjectScript([]);
+
+        $this->assertSame(0, $result['exit_code']);
+        $this->assertSame('Missing id', $result['output']);
+    }
+
+    public function testListProjectRejectsGroupWithoutPermission()
+    {
+        $result = $this->runListProjectScript(['id' => 400], true);
+
+        $this->assertSame(0, $result['exit_code']);
+        $this->assertSame('Permission error', $result['output']);
+    }
+
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testStudentListProjectShowsTopBoxAndEditableRepositoryForm()
+    {
+        $prof = $this->createPageUser('ist5000', 'Professor Example', ROLE_PROF);
+        $student = $this->createPageUser('ist5001', 'Alice Student', ROLE_STUDENT);
+        $student->repository_user = 'github:alice';
+
+        $group = $this->createGroup(5, 2025, $prof, [$student]);
+        $deadline = new \Deadline(2025);
+        $deadline->proj_proposal = new \DateTimeImmutable('+1 day');
+
+        $oldEntityManager = $this->mockListProjectEntityManager($group, $deadline);
+
+        try {
+            $this->setUpPageRuntime('listproject', $student, 'GET', ['id' => $group->id]);
+            $this->runPage('listproject');
+
+            $this->assertNotNull($GLOBALS['top_box']);
+            $this->assertCount(1, $GLOBALS['top_box']['Students']);
+            $this->assertSame(
+                'https://fenix.tecnico.ulisboa.pt/user/photo/ist5001',
+                $GLOBALS['top_box']['Students'][0][0]['data']
+            );
+            $this->assertSame('Alice Student (ist5001)', $GLOBALS['top_box']['Students'][0][1]);
+            $this->assertSame('ist5001@example.com', $GLOBALS['top_box']['Students'][0][2]['data']);
+            $this->assertSame(
+                'github:alice',
+                $GLOBALS['top_box']['Students'][0][3]['label']
+            );
+            $this->assertSame(
+                'https://github.com/alice',
+                $GLOBALS['top_box']['Students'][0][3]['url']
+            );
+            $this->assertStringContainsString('[name: Alice User]', $GLOBALS['top_box']['Students'][0][4]);
+            $this->assertStringContainsString('[email: alice@example.com]', $GLOBALS['top_box']['Students'][0][4]);
+
+            $this->assertCount(1, $GLOBALS['top_box']['Professor']);
+            $this->assertSame('Professor Example', $GLOBALS['top_box']['Professor'][0][1]);
+            $this->assertSame('ist5000@example.com', $GLOBALS['top_box']['Professor'][0][2]['data']);
+
+            $this->assertSame(
+                'You can submit this form multiple times until the deadline. Only the last submission will be considered.',
+                $GLOBALS['info_message']
+            );
+            $this->assertNotNull($GLOBALS['form']);
+            $this->assertTrue($GLOBALS['form']->has('repository'));
+            $this->assertFalse($GLOBALS['form']->get('repository')->getConfig()->getOption('disabled'));
+            $this->assertFalse($GLOBALS['form']->get('submit')->getConfig()->getOption('disabled'));
+            $this->assertNull($GLOBALS['bottom_links']);
+
+            $this->assertCount(1, $GLOBALS['__page_test_eval_boxes']);
+            $this->assertSame('project', $GLOBALS['__page_test_eval_boxes'][0]['page']);
+            $this->assertSame($group, $GLOBALS['__page_test_eval_boxes'][0]['group']);
+        } finally {
+            $GLOBALS['entityManager'] = $oldEntityManager;
+        }
+    }
+
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testListProjectShowsInvalidRepositoryUser()
+    {
+        $oldClient = $GLOBALS['github_client'] ?? null;
+        $GLOBALS['github_client'] = new class {
+            public function api($endpoint)
+            {
+                return new class {
+                    public function show($username)
+                    {
+                        throw new \Github\Exception\RuntimeException('Not Found');
+                    }
+                };
+            }
+        };
+
+        $student = $this->createPageUser('ist5500', 'Invalid Repo User', ROLE_STUDENT);
+        $student->repository_user = 'github:missing';
+        $group = $this->createGroup(55, 2025, null, [$student]);
+        $deadline = new \Deadline(2025);
+        $deadline->proj_proposal = new \DateTimeImmutable('+1 day');
+
+        $oldEntityManager = $this->mockListProjectEntityManager($group, $deadline);
+
+        try {
+            $this->setUpPageRuntime('listproject', $student, 'GET', ['id' => $group->id]);
+            $this->runPage('listproject');
+
+            $this->assertSame(
+                'Invalid Repository User',
+                $GLOBALS['top_box']['Students'][0][3]
+            );
+        } finally {
+            $GLOBALS['github_client'] = $oldClient;
+            $GLOBALS['entityManager'] = $oldEntityManager;
+        }
+    }
+
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testTaListProjectAddsBottomLinks()
+    {
+        $ta = $this->createPageUser('ist6000', 'Taylor Assistant', ROLE_TA);
+        $prof = $this->createPageUser('ist6001', 'Professor Example', ROLE_PROF);
+        $group = $this->createGroup(6, 2025, $ta, [$this->createPageUser('ist6002', 'Sam Student', ROLE_STUDENT)]);
+        $group->shift->prof = $ta;
+
+        $deadline = new \Deadline(2025);
+        $deadline->proj_proposal = new \DateTimeImmutable('+1 day');
+
+        $oldEntityManager = $this->mockListProjectEntityManager($group, $deadline);
+
+        try {
+            $this->setUpPageRuntime('listproject', $ta, 'GET', ['id' => $group->id]);
+            $this->runPage('listproject');
+
+            $this->assertCount(5, $GLOBALS['bottom_links']);
+            $this->assertSame('Grades', $GLOBALS['bottom_links'][0]['label']);
+            $this->assertSame(
+                'index.php?group=' . $group->id . '&year=2025&all_shifts=1&page=grades',
+                $GLOBALS['bottom_links'][0]['url']
+            );
+            $this->assertSame('Patches', $GLOBALS['bottom_links'][1]['label']);
+            $this->assertSame('Bugs', $GLOBALS['bottom_links'][2]['label']);
+            $this->assertSame('Feature', $GLOBALS['bottom_links'][3]['label']);
+            $this->assertSame('Final Report', $GLOBALS['bottom_links'][4]['label']);
+        } finally {
+            $GLOBALS['entityManager'] = $oldEntityManager;
+        }
+    }
+
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testListProjectShowsRepositoryInfoBoxWithThresholdWarnings()
+    {
+        $oldClient = $this->mockCachedGitHubClientForListProject(
+            linesOfCode: 80_000,
+            commitsLastMonth: 60,
+            stars: 250,
+            topics: ['php', 'education']
+        );
+
+        $student = $this->createPageUser('ist6500', 'Repo Student', ROLE_STUDENT);
+        $group = $this->createGroup(65, 2025, null, [$student]);
+        $group->repository = 'github:owner/repo';
+
+        $deadline = new \Deadline(2025);
+        $deadline->proj_proposal = new \DateTimeImmutable('+1 day');
+
+        $oldEntityManager = $this->mockListProjectEntityManager($group, $deadline);
+
+        try {
+            $this->setUpPageRuntime('listproject', $student, 'GET', ['id' => $group->id]);
+            $this->runPage('listproject');
+
+            $this->assertSame('Repository data', $GLOBALS['info_box']['title']);
+            $this->assertSame('PHP', $GLOBALS['info_box']['rows']['Main language']);
+            $this->assertSame(
+                ['data' => "80\u{202F}k", 'warn' => true],
+                $GLOBALS['info_box']['rows']['Lines of Code']
+            );
+            $this->assertSame(60, $GLOBALS['info_box']['rows']['Num of commits in the past month']);
+            $this->assertSame('250', (string)$GLOBALS['info_box']['rows']['Stars']);
+            $this->assertSame('MIT', $GLOBALS['info_box']['rows']['License']);
+            $this->assertSame('php, education', $GLOBALS['info_box']['rows']['Topics']);
+        } finally {
+            $GLOBALS['github_client_cached'] = $oldClient;
+            $GLOBALS['entityManager'] = $oldEntityManager;
+        }
+    }
+
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testListProjectShowsUnavailableRepositoryError()
+    {
+        $oldClient = $this->mockCachedGitHubClientForListProject(isValid: false);
+
+        $student = $this->createPageUser('ist6600', 'Broken Repo Student', ROLE_STUDENT);
+        $group = $this->createGroup(66, 2025, null, [$student]);
+        $group->repository = 'github:owner/missing';
+
+        $deadline = new \Deadline(2025);
+        $deadline->proj_proposal = new \DateTimeImmutable('+1 day');
+
+        $oldEntityManager = $this->mockListProjectEntityManager($group, $deadline);
+
+        try {
+            $this->setUpPageRuntime('listproject', $student, 'GET', ['id' => $group->id]);
+            $this->runPage('listproject');
+
+            $this->assertSame('Repository data', $GLOBALS['info_box']['title']);
+            $this->assertSame(
+                'The repository is no longer available!',
+                $GLOBALS['info_box']['rows']['Error']
+            );
+        } finally {
+            $GLOBALS['github_client_cached'] = $oldClient;
+            $GLOBALS['entityManager'] = $oldEntityManager;
+        }
+    }
+
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testStudentListProjectMakesRepositoryReadOnlyAfterDeadline()
+    {
+        $student = $this->createPageUser('ist7000', 'Late Student', ROLE_STUDENT);
+        $group = $this->createGroup(7, 2025, null, [$student]);
+        $group->allow_modifications_date = new \DateTimeImmutable('-2 days');
+
+        $deadline = new \Deadline(2025);
+        $deadline->proj_proposal = new \DateTimeImmutable('-1 day');
+
+        $oldEntityManager = $this->mockListProjectEntityManager($group, $deadline);
+
+        try {
+            $this->setUpPageRuntime('listproject', $student, 'GET', ['id' => $group->id]);
+            $this->runPage('listproject');
+
+            $this->assertNotNull($GLOBALS['form']);
+            $this->assertTrue($GLOBALS['form']->get('repository')->getConfig()->getOption('disabled'));
+            $this->assertTrue($GLOBALS['form']->get('submit')->getConfig()->getOption('disabled'));
+            $this->assertNull($GLOBALS['info_message']);
+        } finally {
+            $GLOBALS['entityManager'] = $oldEntityManager;
+        }
+    }
+
+    private function createGroup(int $number, int $year, ?\User $prof, array $students): \ProjGroup
+    {
+        return $this->createPageGroup(
+            $number,
+            $year,
+            $students,
+            prof: $prof,
+            groupId: $number * 100,
+            shiftId: $number * 10
+        );
+    }
+
+    private function mockListProjectEntityManager(?\ProjGroup $group, \Deadline $deadline): mixed
+    {
+        $oldEntityManager = $GLOBALS['entityManager'] ?? null;
+        $GLOBALS['entityManager'] = new class($group, $deadline) {
+            public function __construct(
+                private ?\ProjGroup $group,
+                private \Deadline $deadline
+            ) {}
+
+            public function find(string $entity, $id): mixed
+            {
+                if ($entity === 'ProjGroup') {
+                    return $this->group;
+                }
+
+                if ($entity === 'Deadline') {
+                    return $this->deadline;
+                }
+
+                return null;
+            }
+        };
+
+        return $oldEntityManager;
+    }
+
+    private function mockCachedGitHubClientForListProject(
+        bool $isValid = true,
+        int $linesOfCode = 150_000,
+        int $commitsLastMonth = 10,
+        int $stars = 1234,
+        array $topics = ['php', 'testing']
+    ): mixed {
+        $oldClient = $GLOBALS['github_client_cached'] ?? null;
+        $GLOBALS['github_client_cached'] = new class($isValid, $linesOfCode, $commitsLastMonth, $stars, $topics) {
+            public function __construct(
+                private bool $isValid,
+                private int $linesOfCode,
+                private int $commitsLastMonth,
+                private int $stars,
+                private array $topics
+            ) {}
+
+            public function api($endpoint)
+            {
+                return new class(
+                    $this->isValid,
+                    $this->linesOfCode,
+                    $this->commitsLastMonth,
+                    $this->stars,
+                    $this->topics
+                ) {
+                    public function __construct(
+                        private bool $isValid,
+                        private int $linesOfCode,
+                        private int $commitsLastMonth,
+                        private int $stars,
+                        private array $topics
+                    ) {}
+
+                    public function show($owner, $repo)
+                    {
+                        if (!$this->isValid) {
+                            throw new \Github\Exception\RuntimeException('Not Found');
+                        }
+
+                        return [
+                            'full_name' => "$owner/$repo",
+                            'language' => 'PHP',
+                            'license' => ['name' => 'MIT'],
+                            'stargazers_count' => $this->stars,
+                            'topics' => $this->topics,
+                        ];
+                    }
+
+                    public function languages($owner, $repo)
+                    {
+                        return ['PHP' => $this->linesOfCode * 40];
+                    }
+
+                    public function participation($owner, $repo)
+                    {
+                        return [
+                            'all' => array_merge(
+                                array_fill(0, 48, 0),
+                                [0, 0, 0, $this->commitsLastMonth]
+                            ),
+                        ];
+                    }
+                };
+            }
+        };
+
+        return $oldClient;
+    }
+
+    private function runListProjectScript(array $query, bool $returnNullGroup = false): array
+    {
+        $script = sys_get_temp_dir() . '/pic1_listproject_' . bin2hex(random_bytes(4)) . '.php';
+        $queryExport = var_export(['page' => 'listproject'] + $query, true);
+        $bootstrap = var_export(dirname(__DIR__, 3) . '/tests/bootstrap.php', true);
+        $page = var_export(dirname(__DIR__, 3) . '/pages/listproject.php', true);
+        $entityManager = $returnNullGroup
+            ? <<<'PHP'
+$GLOBALS['entityManager'] = new class {
+    public function find(string $entity, $id): mixed
+    {
+        return null;
+    }
+};
+PHP
+            : '';
+
+        $code = <<<PHP
+<?php
+require $bootstrap;
+\$_SERVER['HTTP_HOST'] = 'localhost';
+\$_GET = $queryExport;
+\$_POST = [];
+\$_REQUEST = \$_GET;
+$entityManager
+require $page;
+PHP;
+
+        file_put_contents($script, $code);
+
+        try {
+            $output = [];
+            $exitCode = 0;
+            exec(escapeshellarg(PHP_BINARY) . ' ' . escapeshellarg($script), $output, $exitCode);
+
+            return [
+                'output' => implode("\n", $output),
+                'exit_code' => $exitCode,
+            ];
+        } finally {
+            @unlink($script);
+        }
+    }
+}

--- a/tests/Integration/Pages/ListProjectsPageTest.php
+++ b/tests/Integration/Pages/ListProjectsPageTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Tests\Integration\Pages;
+
+
+
+class ListProjectsPageTest extends PageTestCase
+{
+    public function testStudentListProjectsUsesUserGroups()
+    {
+        $student = $this->createPageUser('ist1000', 'Alice Student', ROLE_STUDENT);
+        $group = $this->createGroup(7, 2025, [$student]);
+
+        $this->setUpPageRuntime('listprojects', $student);
+        $this->runPage('listprojects');
+
+        $this->assertCount(1, $GLOBALS['table']);
+        $this->assertSame(7, $GLOBALS['table'][0]['Group']['label']);
+        $this->assertSame(
+            "Alice Student (ist1000)",
+            $GLOBALS['table'][0]['Students']
+        );
+        $this->assertSame(
+            'index.php?id=' . $group->id . '&page=listproject',
+            $GLOBALS['table'][0]['Group']['url']
+        );
+    }
+
+    public function testTaListProjectsUsesFilteredGroups()
+    {
+        $ta = $this->createPageUser('ist2000', 'Taylor Assistant', ROLE_TA);
+        $student = $this->createPageUser('ist2001', 'Sam Student', ROLE_STUDENT);
+        $group = $this->createGroup(3, 2025, [$student]);
+
+        $GLOBALS['__page_test_filter_result'] = [$group];
+
+        $this->setUpPageRuntime('listprojects', $ta);
+        $this->runPage('listprojects');
+
+        $this->assertCount(1, $GLOBALS['table']);
+        $this->assertSame(3, $GLOBALS['table'][0]['Group']['label']);
+        $this->assertSame(
+            "Sam Student (ist2001)",
+            $GLOBALS['table'][0]['Students']
+        );
+    }
+
+    public function testListProjectsBuildsStudentNamesAndGroupLinks()
+    {
+        $studentA = $this->createPageUser('ist3001', 'Alice Student', ROLE_STUDENT);
+        $studentB = $this->createPageUser('ist3002', 'Bob Student', ROLE_STUDENT);
+        $group = $this->createGroup(11, 2025, [$studentA, $studentB]);
+
+        $GLOBALS['__page_test_filter_result'] = [$group];
+
+        $this->setUpPageRuntime(
+            'listprojects',
+            $this->createPageUser('ist3000', 'Professor Example', ROLE_PROF)
+        );
+        $this->runPage('listprojects');
+
+        $this->assertSame(
+            [
+                [
+                    'Group' => [
+                        'label' => 11,
+                        'url' => 'index.php?id=' . $group->id . '&page=listproject',
+                    ],
+                    'Students' => "Alice Student (ist3001)\nBob Student (ist3002)",
+                ],
+            ],
+            $GLOBALS['table']
+        );
+    }
+
+    public function testListProjectsHandlesNoGroups()
+    {
+        $student = $this->createPageUser('ist4000', 'Empty Student', ROLE_STUDENT);
+
+        $this->setUpPageRuntime('listprojects', $student);
+        $this->runPage('listprojects');
+
+        $this->assertSame([], $GLOBALS['table']);
+    }
+
+    private function createGroup(int $number, int $year, array $students): \ProjGroup
+    {
+        return $this->createPageGroup(
+            $number,
+            $year,
+            $students,
+            groupId: $number * 100,
+            shiftId: $number * 10
+        );
+    }
+}

--- a/tests/Integration/Pages/PageTestCase.php
+++ b/tests/Integration/Pages/PageTestCase.php
@@ -1,0 +1,429 @@
+<?php
+
+namespace {
+    if (!function_exists('get_user')) {
+        function get_user()
+        {
+            return $GLOBALS['__page_test_user'];
+        }
+    }
+
+    if (!function_exists('auth_at_least')) {
+        function auth_at_least($role)
+        {
+            return auth_user_at_least(get_user(), $role);
+        }
+    }
+
+    if (!function_exists('auth_require_at_least')) {
+        function auth_require_at_least($role)
+        {
+            if (!auth_at_least($role)) {
+                die('Unauthorized access');
+            }
+        }
+    }
+
+    if (!function_exists('has_shift_permissions')) {
+        function has_shift_permissions(\Shift $shift)
+        {
+            $user = get_user();
+            return match ($user->role) {
+                ROLE_SUDO, ROLE_PROF => true,
+                ROLE_TA => $shift->prof == $user,
+                ROLE_STUDENT => $user->groups->exists(fn ($key, $group) => $group->shift == $shift),
+            };
+        }
+    }
+
+    if (!function_exists('has_group_permissions')) {
+        function has_group_permissions(\ProjGroup $group)
+        {
+            $user = get_user();
+            return match ($user->role) {
+                ROLE_SUDO, ROLE_PROF => true,
+                ROLE_TA => $group->shift->prof == $user,
+                ROLE_STUDENT => $user->groups->contains($group),
+            };
+        }
+    }
+
+    if (!function_exists('dourl')) {
+        function dourl($page, $args = [])
+        {
+            $args['page'] = $page;
+            return 'index.php?' . http_build_query($args, '', '&');
+        }
+    }
+
+    if (!function_exists('dolink_ext')) {
+        function dolink_ext($url, $txt)
+        {
+            return ['label' => $txt, 'url' => (string)$url];
+        }
+    }
+
+    if (!function_exists('dolink')) {
+        function dolink($page, $txt, $args = [])
+        {
+            return dolink_ext(dourl($page, $args), $txt);
+        }
+    }
+
+    if (!function_exists('dolink_group')) {
+        function dolink_group(\ProjGroup $group, $txt)
+        {
+            return dolink('listproject', $txt, ['id' => $group->id]);
+        }
+    }
+
+    if (!function_exists('link_patch')) {
+        function link_patch(\Patch $patch)
+        {
+            return 'https://localhost/' . dourl('editpatch', ['id' => $patch->id]);
+        }
+    }
+
+    if (!function_exists('terminate')) {
+        function terminate($error_message = null, $template = 'main.html.twig', $extra_fields = [])
+        {
+            throw new \Tests\Integration\Pages\PageTerminated($error_message, $template, $extra_fields);
+        }
+    }
+
+    if (!function_exists('terminate_redirect')) {
+        function terminate_redirect()
+        {
+            throw new \Tests\Integration\Pages\PageRedirected($_SERVER['REQUEST_URI'] ?? '');
+        }
+    }
+
+    if (!function_exists('handle_form')) {
+        function handle_form(&$obj, $hide_fields, $readonly, $only_fields = null, $in_required = null)
+        {
+            global $form, $formFactory, $request, $success_message;
+
+            $builder = $formFactory->createBuilder(
+                \Symfony\Component\Form\Extension\Core\Type\FormType::class
+            );
+            $editable = false;
+            $fieldNames = [];
+
+            foreach (get_object_vars($obj) as $name => $value) {
+                if (in_array($name, $hide_fields, true) ||
+                    ($only_fields && !in_array($name, $only_fields, true))) {
+                    continue;
+                }
+
+                $fieldNames[] = $name;
+                $disabled = in_array($name, $readonly, true);
+                $editable = $editable || !$disabled;
+                $required = $in_required ? in_array($name, $in_required, true) : true;
+                $label = strtr($name, '_', ' ');
+
+                if (is_bool($value)) {
+                    $type = \Symfony\Component\Form\Extension\Core\Type\CheckboxType::class;
+                    $options = [
+                        'label' => $label,
+                        'data' => $value,
+                        'required' => false,
+                        'disabled' => $disabled,
+                    ];
+                } elseif (is_int($value)) {
+                    $type = \Symfony\Component\Form\Extension\Core\Type\IntegerType::class;
+                    $options = [
+                        'label' => $label,
+                        'data' => $value,
+                        'required' => $required,
+                        'disabled' => $disabled,
+                    ];
+                } elseif ($value instanceof \DateTimeInterface) {
+                    $type = \Symfony\Component\Form\Extension\Core\Type\DateTimeType::class;
+                    $options = [
+                        'label' => $label,
+                        'data' => $value,
+                        'input' => 'datetime_immutable',
+                        'widget' => 'single_text',
+                        'required' => $required,
+                        'disabled' => $disabled,
+                    ];
+                } elseif ($value instanceof \UnitEnum) {
+                    $type = \Symfony\Component\Form\Extension\Core\Type\EnumType::class;
+                    $options = [
+                        'class' => get_class($value),
+                        'label' => $label,
+                        'data' => $value,
+                        'required' => $required,
+                        'disabled' => $disabled,
+                    ];
+                } else {
+                    $stringValue = (string)$value;
+                    $type = str_contains($name, 'url') || str_starts_with($stringValue, 'https://')
+                        ? \Symfony\Component\Form\Extension\Core\Type\UrlType::class
+                        : \Symfony\Component\Form\Extension\Core\Type\TextType::class;
+                    $options = [
+                        'label' => $label,
+                        'data' => $stringValue,
+                        'required' => $required,
+                        'disabled' => $disabled,
+                    ];
+                }
+
+                $builder->add($name, $type, $options);
+            }
+
+            $builder->add('submit', \Symfony\Component\Form\Extension\Core\Type\SubmitType::class, [
+                'label' => 'Save changes',
+                'disabled' => !$editable,
+            ]);
+
+            $form = $builder->getForm();
+            $form->handleRequest($request);
+
+            if ($form->isSubmitted() && $form->isValid()) {
+                foreach ($fieldNames as $name) {
+                    if (in_array($name, $readonly, true)) {
+                        continue;
+                    }
+
+                    $value = $form->get($name)->getData() ?? '';
+                    $setter = "set_$name";
+                    if (method_exists($obj, $setter)) {
+                        $obj->$setter($value);
+                    } else {
+                        $obj->$name = $value;
+                    }
+                }
+                $success_message = 'Database updated!';
+            }
+        }
+    }
+
+    if (!function_exists('filter_by')) {
+        function filter_by($filters, $extra_filters = [])
+        {
+            return $GLOBALS['__page_test_filter_result'] ?? [];
+        }
+    }
+
+    if (!function_exists('mk_eval_box')) {
+        function mk_eval_box(int $year, ?string $page, ?\User $student, ?\ProjGroup $group)
+        {
+            $GLOBALS['__page_test_eval_boxes'][] = compact('year', 'page', 'student', 'group');
+        }
+    }
+
+    if (!function_exists('get_term_for')) {
+        function get_term_for($year)
+        {
+            return "$year/" . ($year + 1);
+        }
+    }
+
+    if (!function_exists('markdown_to_html')) {
+        function markdown_to_html($text)
+        {
+            return $text;
+        }
+    }
+
+    if (!function_exists('validate_role')) {
+        function validate_role($role, $allow_sudo)
+        {
+            return is_int($role) &&
+                $role >= ($allow_sudo ? ROLE_SUDO : ROLE_PROF) &&
+                $role <= ROLE_STUDENT;
+        }
+    }
+
+    if (!function_exists('auth_set_user')) {
+        function auth_set_user($user)
+        {
+            $GLOBALS['__page_test_auth_set_user'][] = $user;
+            $GLOBALS['__page_test_user'] = $user;
+        }
+    }
+}
+
+namespace Tests\Integration\Pages {
+    use Symfony\Component\Form\Extension\HttpFoundation\HttpFoundationExtension;
+    use Symfony\Component\Form\Forms;
+    use Symfony\Component\HttpFoundation\Request;
+    use Tests\Integration\Base\IntegrationTestCase;
+
+    class PageTerminated extends \RuntimeException
+    {
+        public function __construct(
+            public readonly ?string $errorMessage = null,
+            public readonly string $template = 'main.html.twig',
+            public readonly array $extraFields = []
+        ) {
+            parent::__construct($errorMessage ?? '');
+        }
+    }
+
+    class PageRedirected extends \RuntimeException
+    {
+        public function __construct(public readonly string $url)
+        {
+            parent::__construct($url);
+        }
+    }
+
+    abstract class PageTestCase extends IntegrationTestCase
+    {
+        private array $originalRuntimeGlobals = [];
+
+        protected function setUp(): void
+        {
+            parent::setUp();
+
+            foreach (['_GET', '_POST', '_REQUEST', '_SESSION', '_SERVER', 'page'] as $name) {
+                $this->originalRuntimeGlobals[$name] = [
+                    'exists' => array_key_exists($name, $GLOBALS),
+                    'value' => $GLOBALS[$name] ?? null,
+                ];
+            }
+
+            $_SERVER['HTTP_HOST'] = 'localhost';
+        }
+
+        protected function tearDown(): void
+        {
+            unset(
+                $GLOBALS['__page_test_user'],
+                $GLOBALS['__page_test_filter_result'],
+                $GLOBALS['__page_test_eval_boxes'],
+                $GLOBALS['__page_test_auth_set_user'],
+                $GLOBALS['__page_test_saved_bugs'],
+                $GLOBALS['__page_test_deadline_year'],
+                $GLOBALS['__page_test_shifts_year'],
+                $GLOBALS['__patches_page_create_patch'],
+                $GLOBALS['__patches_page_save_patch'],
+                $GLOBALS['__patches_page_email_ta'],
+                $GLOBALS['__editpatch_page_email_ta'],
+                $GLOBALS['__editpatch_page_email_group'],
+                $GLOBALS['__patches_email'],
+                $GLOBALS['__editpatch_emails'],
+                $GLOBALS['patch']
+            );
+
+            foreach ($this->originalRuntimeGlobals as $name => $original) {
+                if ($original['exists']) {
+                    $GLOBALS[$name] = $original['value'];
+                } else {
+                    unset($GLOBALS[$name]);
+                }
+            }
+            $this->originalRuntimeGlobals = [];
+
+            parent::tearDown();
+        }
+
+        protected function createPageUser(
+            string $id = 'student',
+            string $name = 'Test Student',
+            int $role = ROLE_STUDENT
+        ): \User {
+            return new \User($id, $name, "$id@example.com", '', $role, false);
+        }
+
+        protected function createPageGroup(
+            int $number,
+            int $year,
+            array $students,
+            ?\User $prof = null,
+            ?int $groupId = null,
+            ?int $shiftId = null,
+            string $repository = ''
+        ): \ProjGroup {
+            $shift = new \Shift('T1', $year);
+            if ($shiftId !== null) {
+                $shift->id = $shiftId;
+            }
+            $shift->prof = $prof;
+
+            $group = new \ProjGroup($number, $year, $shift);
+            if ($groupId !== null) {
+                $group->id = $groupId;
+            }
+            $group->repository = $repository;
+
+            foreach ($students as $student) {
+                $group->addStudent($student);
+            }
+
+            return $group;
+        }
+
+        protected function setUpPageRuntime(
+            string $page,
+            ?\User $user = null,
+            string $method = 'GET',
+            array $query = [],
+            array $requestData = []
+        ): void {
+            global $formFactory, $request;
+            global $custom_header, $form, $select_form, $comments_form;
+            global $eval_forms, $copy_form, $embed_file, $info_message;
+            global $success_message, $table, $lists, $deadline, $top_box;
+            global $info_box, $monospace, $bottom_links, $refresh_url;
+            global $confirm, $large_video, $comments, $ci_failures;
+            global $display_formula, $plots, $milestones;
+
+            $GLOBALS['page'] = $page;
+            $GLOBALS['__page_test_user'] = $user ?? $this->createPageUser();
+
+            $_GET = ['page' => $page] + $query;
+            $_POST = $method === 'POST' ? $requestData : [];
+            $_REQUEST = $_GET + $_POST;
+
+            $request = Request::create(
+                '/index.php?page=' . $page,
+                $method,
+                $method === 'POST' ? $_POST : $_GET
+            );
+            $formFactory = Forms::createFormFactoryBuilder()
+                ->addExtension(new HttpFoundationExtension())
+                ->getFormFactory();
+
+            $custom_header = null;
+            $form = null;
+            $select_form = null;
+            $comments_form = null;
+            $eval_forms = [];
+            $copy_form = null;
+            $embed_file = null;
+            $info_message = null;
+            $success_message = null;
+            $table = null;
+            $lists = null;
+            $deadline = null;
+            $top_box = null;
+            $info_box = null;
+            $monospace = null;
+            $bottom_links = null;
+            $refresh_url = null;
+            $confirm = null;
+            $large_video = null;
+            $comments = null;
+            $ci_failures = null;
+            $display_formula = null;
+            $plots = null;
+            $milestones = null;
+        }
+
+        protected function runPage(string $page): void
+        {
+            global $formFactory, $request;
+            global $custom_header, $form, $select_form, $comments_form;
+            global $eval_forms, $copy_form, $embed_file, $info_message;
+            global $success_message, $table, $lists, $deadline, $top_box;
+            global $info_box, $monospace, $bottom_links, $refresh_url;
+            global $confirm, $large_video, $comments, $ci_failures;
+            global $display_formula, $plots, $milestones;
+
+            require dirname(__DIR__, 3) . "/pages/$page.php";
+        }
+    }
+}

--- a/tests/Integration/Pages/PatchesPageTest.php
+++ b/tests/Integration/Pages/PatchesPageTest.php
@@ -1,0 +1,585 @@
+<?php
+
+namespace Tests\Integration\Pages;
+
+use Tests\Mocks\FakePatch;
+use Tests\Mocks\FakePullRequest;
+require_once dirname(__DIR__, 3) . '/entities/Patch.php';
+
+class PatchesPageTest extends PageTestCase
+{
+    public function testPatchesPageTerminatesWhenSubmittingWithoutGroup()
+    {
+        $year = get_current_year();
+        $oldEntityManager = $this->mockPatchesEntityManager($this->openDeadline($year));
+
+        try {
+            $student = $this->createPageUser('ist9900', 'No Group Student', ROLE_STUDENT);
+            $student->repository_user = 'github:nogroup';
+
+            $this->setUpPageRuntime(
+                'patches',
+                $student,
+                'POST',
+                [],
+                ['form' => $this->submissionFormData()]
+            );
+
+            $this->expectException(PageTerminated::class);
+            $this->expectExceptionMessage('Student is not in a group');
+            $this->runPage('patches');
+        } finally {
+            $GLOBALS['entityManager'] = $oldEntityManager;
+        }
+    }
+
+    public function testPatchesPageTerminatesWhenStudentHasNoRepositoryUser()
+    {
+        $year = get_current_year();
+        $oldEntityManager = $this->mockPatchesEntityManager($this->openDeadline($year));
+
+        try {
+            $student = $this->createPageUser('ist9901', 'No Repo User', ROLE_STUDENT);
+            $student->email = 'ist9901@tecnico.ulisboa.pt';
+            $this->createGroup(41, $year, [$student]);
+
+            $this->setUpPageRuntime(
+                'patches',
+                $student,
+                'POST',
+                [],
+                ['form' => $this->submissionFormData()]
+            );
+
+            $this->expectException(PageTerminated::class);
+            $this->expectExceptionMessage('Student does not have an associated repository user');
+            $this->runPage('patches');
+        } finally {
+            $GLOBALS['entityManager'] = $oldEntityManager;
+        }
+    }
+
+    public function testPatchesPageBuildsStudentFormAndPatchTable()
+    {
+        $year = get_current_year();
+        $oldEntityManager = $this->mockPatchesEntityManager($this->openDeadline($year));
+
+        try {
+            $student = $this->createPageUser('ist9902', 'Alice Student', ROLE_STUDENT);
+            $group = $this->createGroup(42, $year, [$student]);
+            $group->url_proposal = 'https://example.org/issues/42';
+
+            $patch = $this->createPatchStub(
+                id: 701,
+                group: $group,
+                submitter: $student,
+                authors: [$student],
+                status: \PatchStatus::WaitingReview,
+                type: \PatchType::Feature,
+                patchUrl: 'https://github.com/owner/repo/tree/feature-branch',
+                prUrl: null,
+                linesAdded: 14,
+                linesDeleted: 3,
+                filesModified: 2
+            );
+            $group->patches->add($patch);
+
+            $this->setUpPageRuntime('patches', $student);
+            $this->runPage('patches');
+
+            $this->assertNotNull($GLOBALS['form']);
+            $this->assertTrue($GLOBALS['form']->has('url'));
+            $this->assertTrue($GLOBALS['form']->has('type'));
+            $this->assertTrue($GLOBALS['form']->has('video_url'));
+            $this->assertTrue($GLOBALS['form']->has('description'));
+            $this->assertTrue($GLOBALS['form']->has('submit'));
+
+            $this->assertCount(1, $GLOBALS['table']);
+            $row = $GLOBALS['table'][0];
+            $this->assertSame(701, $row['id']['label']);
+            $this->assertSame('index.php?id=701&page=editpatch', $row['id']['url']);
+            $this->assertSame(42, $row['Group']['label']);
+            $this->assertSame('index.php?id=' . $group->id . '&page=listproject', $row['Group']['url']);
+            $this->assertSame('waiting review', $row['Status']);
+            $this->assertSame('feature', $row['Type']);
+            $this->assertSame('https://example.org/issues/42', $row['Issue']['url']);
+            $this->assertSame('https://github.com/owner/repo/tree/feature-branch', $row['Patch']['url']);
+            $this->assertSame('', $row['PR']);
+            $this->assertSame(14, $row['+']);
+            $this->assertSame(3, $row['-']);
+            $this->assertSame(2, $row['Files']);
+            $this->assertSame('Alice Student', $row['Submitter']);
+            $this->assertSame('Alice Student', $row['Authors']);
+            $this->assertTrue($row['_large_table']);
+        } finally {
+            $GLOBALS['entityManager'] = $oldEntityManager;
+        }
+    }
+
+    public function testPatchesPageDoesNotBuildStudentFormAfterDeadline()
+    {
+        $year = get_current_year();
+        $oldEntityManager = $this->mockPatchesEntityManager($this->closedDeadline($year));
+
+        try {
+            $student = $this->createPageUser('ist9906', 'Late Student', ROLE_STUDENT);
+            $group = $this->createGroup(46, $year, [$student]);
+            $patch = $this->createPatchStub(
+                id: 704,
+                group: $group,
+                submitter: $student,
+                authors: [$student],
+                status: \PatchStatus::WaitingReview,
+                type: \PatchType::Feature,
+                patchUrl: 'https://github.com/owner/repo/tree/late-branch',
+                prUrl: null,
+                linesAdded: 12,
+                linesDeleted: 1,
+                filesModified: 1
+            );
+            $group->patches->add($patch);
+
+            $this->setUpPageRuntime('patches', $student);
+            $this->runPage('patches');
+
+            $this->assertNull($GLOBALS['form']);
+            $this->assertCount(1, $GLOBALS['table']);
+            $this->assertSame(704, $GLOBALS['table'][0]['id']['label']);
+        } finally {
+            $GLOBALS['entityManager'] = $oldEntityManager;
+        }
+    }
+
+    public function testPatchesPageFiltersTaViewByReviewAndOpenStateWithoutSubmissionForm()
+    {
+        $year = get_current_year();
+        $oldEntityManager = $this->mockPatchesEntityManager($this->openDeadline($year));
+
+        try {
+            $ta = $this->createPageUser('ist9903', 'Taylor Assistant', ROLE_TA);
+
+            $studentA = $this->createPageUser('ist9904', 'Alice Student', ROLE_STUDENT);
+            $groupA = $this->createGroup(43, $year, [$studentA]);
+            $groupA->url_proposal = 'https://example.org/issues/43';
+            $waitingReview = $this->createPatchStub(
+                id: 702,
+                group: $groupA,
+                submitter: $studentA,
+                authors: [$studentA],
+                status: \PatchStatus::WaitingReview,
+                type: \PatchType::Feature,
+                patchUrl: 'https://github.com/owner/repo/tree/review-branch',
+                prUrl: 'https://github.com/owner/repo/pull/12',
+                linesAdded: 20,
+                linesDeleted: 4,
+                filesModified: 3
+            );
+            $groupA->patches->add($waitingReview);
+
+            $studentB = $this->createPageUser('ist9905', 'Bob Student', ROLE_STUDENT);
+            $groupB = $this->createGroup(44, $year, [$studentB]);
+            $groupB->url_proposal = 'https://example.org/issues/44';
+            $merged = $this->createPatchStub(
+                id: 703,
+                group: $groupB,
+                submitter: $studentB,
+                authors: [$studentB],
+                status: \PatchStatus::Merged,
+                type: \PatchType::Feature,
+                patchUrl: 'https://github.com/owner/repo/tree/merged-branch',
+                prUrl: 'https://github.com/owner/repo/pull/13',
+                linesAdded: 30,
+                linesDeleted: 5,
+                filesModified: 4
+            );
+            $groupB->patches->add($merged);
+
+            $GLOBALS['__page_test_filter_result'] = [[$groupA, $groupB], true, true];
+
+            $this->setUpPageRuntime('patches', $ta);
+            $this->runPage('patches');
+
+            $this->assertNull($GLOBALS['form']);
+            $this->assertCount(1, $GLOBALS['table']);
+            $row = $GLOBALS['table'][0];
+            $this->assertSame(702, $row['id']['label']);
+            $this->assertSame('waiting review', $row['Status']);
+            $this->assertSame('https://github.com/owner/repo/pull/12', $row['PR']['url']);
+            $this->assertSame('Alice Student', $row['Authors']);
+        } finally {
+            $GLOBALS['entityManager'] = $oldEntityManager;
+        }
+    }
+
+    public function testPatchesPageSubmitsPatchSuccessfully()
+    {
+        $result = $this->runPatchesSubmissionScript(duplicate: false);
+
+        $this->assertSame(0, $result['exit_code']);
+        $data = json_decode($result['output'], true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame('Patch submitted successfully!', $data['success_message']);
+        $this->assertSame(1, $data['patch_count']);
+        $this->assertSame(1, $data['saved_count']);
+        $this->assertSame('feature', $data['saved_patch_type']);
+        $this->assertSame('https://github.com/owner/repo/compare/alice%3Arepo%3Afeature-branch', $data['saved_patch_url']);
+        $this->assertSame('Stub AI review', $data['review_text']);
+        $this->assertSame('PIC1: New patch', $data['email_subject']);
+        $this->assertSame('ta@example.com', $data['email_to']);
+    }
+
+    public function testPatchesPageShowsFriendlyMessageForDuplicateBranch()
+    {
+        $result = $this->runPatchesSubmissionScript(duplicate: true);
+
+        $this->assertSame(0, $result['exit_code']);
+        $data = json_decode($result['output'], true, flags: JSON_THROW_ON_ERROR);
+        $this->assertSame(
+            'A patch with the same branch already exists. Please update the existing patch instead of creating a new one.',
+            $data['error_message']
+        );
+    }
+
+    private function createGroup(int $number, int $year, array $students): \ProjGroup
+    {
+        return $this->createPageGroup(
+            $number,
+            $year,
+            $students,
+            groupId: $number * 100,
+            shiftId: $number * 10,
+            repository: 'github:owner/repo'
+        );
+    }
+
+    private function createPatchStub(
+        int $id,
+        \ProjGroup $group,
+        \User $submitter,
+        array $authors,
+        \PatchStatus $status,
+        \PatchType $type,
+        string $patchUrl,
+        ?string $prUrl,
+        int $linesAdded,
+        int $linesDeleted,
+        int $filesModified
+    ): \Patch {
+        $pr = $prUrl === null ? null : new FakePullRequest(
+            pullRequestUrl: $prUrl,
+            branchUrl: 'https://github.com/owner/repo/tree/feature-branch',
+            pullRequestOrigin: 'alice:repo:feature-branch',
+            addedLines: 20,
+            deletedLines: 4,
+            modifiedFiles: 3
+        );
+        $patch = new FakePatch(
+            patchOrigin: 'alice:repo:feature-branch',
+            patchText: "diff --git a/file.php b/file.php\n",
+            branchHash: 'mockhash',
+            computedLinesAdded: 0,
+            computedLinesDeleted: 0,
+            computedFilesModified: 0,
+            patchUrl: $patchUrl,
+            commitUrlBase: 'https://github.com/owner/repo/commit/',
+            pullRequest: $pr
+        );
+
+        if ($id > 0) {
+            $patch->id = $id;
+        }
+        $patch->group = $group;
+        $patch->status = $status;
+        $patch->type = $type;
+        $patch->lines_added = $linesAdded;
+        $patch->lines_deleted = $linesDeleted;
+        $patch->files_modified = $filesModified;
+        $patch->comments->add(new \PatchComment($patch, 'Patch submitted', $submitter));
+        foreach ($authors as $author) {
+            $patch->students->add($author);
+        }
+
+        return $patch;
+    }
+
+    private function mockPatchesEntityManager(\Deadline $deadline): mixed
+    {
+        $oldEntityManager = $GLOBALS['entityManager'] ?? null;
+        $GLOBALS['entityManager'] = new class($deadline) {
+            public function __construct(private \Deadline $deadline) {}
+
+            public function find(string $entity, $id): mixed
+            {
+                if ($entity === 'Deadline') {
+                    return $this->deadline;
+                }
+
+                return null;
+            }
+
+            public function persist($obj): void
+            {
+            }
+
+            public function flush(): void
+            {
+            }
+        };
+
+        return $oldEntityManager;
+    }
+
+    private function submissionFormData(
+        string $url = 'https://github.com/owner/repo/tree/feature-branch',
+        string $description = 'This patch implements a valid feature description.'
+    ): array {
+        return [
+            'url' => $url,
+            'type' => '1',
+            'video_url' => '',
+            'description' => $description,
+            'submit' => '',
+        ];
+    }
+
+    private function openDeadline(int $year): \Deadline
+    {
+        $deadline = new \Deadline($year);
+        $deadline->patch_submission = new \DateTimeImmutable('+1 day');
+        return $deadline;
+    }
+
+    private function closedDeadline(int $year): \Deadline
+    {
+        $deadline = new \Deadline($year);
+        $deadline->patch_submission = new \DateTimeImmutable('-1 day');
+        return $deadline;
+    }
+
+    private function runPatchesSubmissionScript(bool $duplicate): array
+    {
+        $script = sys_get_temp_dir() . '/pic1_patches_' . bin2hex(random_bytes(4)) . '.php';
+        $bootstrap = var_export(dirname(__DIR__, 3) . '/tests/bootstrap.php', true);
+        $pageTestCase = var_export(dirname(__DIR__) . '/Pages/PageTestCase.php', true);
+        $page = var_export(dirname(__DIR__, 3) . '/pages/patches.php', true);
+        $patchEntity = var_export(dirname(__DIR__, 3) . '/entities/Patch.php', true);
+        $stubDir = sys_get_temp_dir() . '/pic1_patch_stubs_' . bin2hex(random_bytes(4));
+        $duplicateFlag = $duplicate ? 'true' : 'false';
+
+        mkdir($stubDir);
+        file_put_contents(
+            $stubDir . '/email.php',
+            <<<'PHP'
+<?php
+function email_ta($group, $subject, $msg, $html = false) {
+    $GLOBALS['__patches_email'][] = [
+        'to' => $group->shift->prof?->email ?? '',
+        'subject' => $subject,
+        'msg' => $msg,
+        'html' => $html,
+    ];
+}
+PHP
+        );
+        file_put_contents(
+            $stubDir . '/review.php',
+            <<<'PHP'
+<?php
+function review_patch($project_name, $bug_fix, $patch, $patch_description, $issue_url, $issue_description, $coding_standard_url) {
+    return 'Stub AI review';
+}
+PHP
+        );
+
+        $code = <<<PHP
+<?php
+require $bootstrap;
+require $pageTestCase;
+chdir('$stubDir');
+require_once $patchEntity;
+\$_SERVER['HTTP_HOST'] = 'localhost';
+\$_GET = ['page' => 'patches'];
+\$_POST = [
+    'form' => [
+        'url' => 'https://github.com/owner/repo/tree/feature-branch',
+        'type' => '1',
+        'video_url' => '',
+        'description' => 'This patch implements a complete feature for testing.',
+        'submit' => '',
+    ],
+];
+\$_REQUEST = \$_GET + \$_POST;
+\$request = Symfony\Component\HttpFoundation\Request::create('/index.php?page=patches', 'POST', \$_POST);
+\$formFactory = Symfony\Component\Form\Forms::createFormFactoryBuilder()
+    ->addExtension(new Symfony\Component\Form\Extension\HttpFoundation\HttpFoundationExtension())
+    ->getFormFactory();
+\$GLOBALS['page'] = 'patches';
+\$GLOBALS['__patches_email'] = [];
+\$year = get_current_year();
+\$student = new User('ist9910', 'Alice Student', 'ist9910@tecnico.ulisboa.pt', '', ROLE_STUDENT, false);
+\$student->repository_user = 'github:alice';
+\$ta = new User('ist9911', 'TA Reviewer', 'ta@example.com', '', ROLE_TA, false);
+\$shift = new Shift('T1', \$year);
+\$shift->prof = \$ta;
+\$group = new ProjGroup(45, \$year, \$shift);
+\$group->id = 4500;
+\$group->repository = 'github:owner/repo';
+\$group->project_name = 'Patch Project';
+\$group->addStudent(\$student);
+\$GLOBALS['__page_test_user'] = \$student;
+\$GLOBALS['github_client'] = new class {
+    public function api(\$endpoint) {
+        if (\$endpoint === 'user') {
+            return new class {
+                public function show(\$username) {
+                    return ['login' => \$username, 'name' => 'Alice Student', 'email' => 'ist9910@tecnico.ulisboa.pt'];
+                }
+            };
+        }
+        if (\$endpoint === 'repository') {
+            return new class {
+                public function branches(\$org, \$repo, \$branch) {
+                    return [
+                        'name' => \$branch,
+                        'commit' => ['url' => "https://api.github.com/repos/alice/repo/commits/mocksha123"],
+                    ];
+                }
+            };
+        }
+        if (\$endpoint === 'repo') {
+            return new class {
+                public function show(\$owner, \$repo) {
+                    return [
+                        'full_name' => "\$owner/\$repo",
+                        'default_branch' => 'main',
+                        'language' => 'PHP',
+                        'license' => ['name' => 'MIT'],
+                        'stargazers_count' => 100,
+                        'topics' => ['testing'],
+                    ];
+                }
+                public function commits() {
+                    return new class {
+                        public function compare(\$org, \$repo, \$srcBranch, \$repoBranch, \$accept = null) {
+                            if (\$accept === 'application/vnd.github.patch') {
+                                return "diff --git a/src.php b/src.php\n+new line\n";
+                            }
+                            return [
+                                'commits' => [[
+                                    'sha' => 'mocksha123',
+                                    'author' => ['login' => 'alice'],
+                                    'commit' => [
+                                        'author' => ['name' => 'Alice Student', 'email' => 'ist9910@tecnico.ulisboa.pt'],
+                                        'message' => "Implement feature branch support with enough detail.\n\nTechnical explanation of the implementation steps.",
+                                    ],
+                                ]],
+                                'files' => [[
+                                    'filename' => 'src.php',
+                                    'patch' => "+new line\n",
+                                    'additions' => 1,
+                                    'deletions' => 0,
+                                ]],
+                            ];
+                        }
+                    };
+                }
+            };
+        }
+        throw new RuntimeException('Unexpected endpoint: ' . \$endpoint);
+    }
+};
+\$GLOBALS['github_client_cached'] = \$GLOBALS['github_client'];
+\$GLOBALS['entityManager'] = new class(\$group, \$year, $duplicateFlag) {
+    public array \$saved = [];
+
+    public function __construct(
+        private ProjGroup \$group,
+        private int \$year,
+        private bool \$duplicate
+    ) {}
+
+    public function find(string \$entity, \$id): mixed
+    {
+        if (\$entity === 'Deadline') {
+            \$deadline = new Deadline(\$this->year);
+            \$deadline->patch_submission = new DateTimeImmutable('+1 day');
+            return \$deadline;
+        }
+
+        return null;
+    }
+
+    public function persist(\$obj): void
+    {
+        if (\$obj instanceof Patch && !isset(\$obj->id)) {
+            \$obj->id = 8801;
+        }
+        \$this->saved[] = \$obj;
+    }
+
+    public function flush(): void
+    {
+        if (!\$this->duplicate) {
+            return;
+        }
+
+        \$driverException = new class('duplicate branch', 19) extends RuntimeException implements Doctrine\DBAL\Driver\Exception {
+            public function getSQLState(): ?string
+            {
+                return '23000';
+            }
+        };
+
+        throw new Doctrine\DBAL\Exception\UniqueConstraintViolationException(\$driverException, null);
+    }
+};
+try {
+    require $page;
+    \$savedPatch = \$GLOBALS['entityManager']->saved[0] ?? null;
+    \$reviewText = null;
+    if (\$savedPatch) {
+        foreach (\$savedPatch->comments as \$comment) {
+            if (str_contains(\$comment->text, 'Stub AI review')) {
+                \$reviewText = 'Stub AI review';
+                break;
+            }
+        }
+    }
+    echo json_encode([
+        'success_message' => \$success_message ?? null,
+        'error_message' => null,
+        'patch_count' => count(\$group->patches),
+        'saved_count' => count(\$GLOBALS['entityManager']->saved),
+        'saved_patch_type' => \$savedPatch?->getType(),
+        'saved_patch_url' => \$savedPatch?->getPatchURL(),
+        'review_text' => \$reviewText,
+        'email_subject' => \$GLOBALS['__patches_email'][0]['subject'] ?? null,
+        'email_to' => \$GLOBALS['__patches_email'][0]['to'] ?? null,
+    ]);
+} catch (Tests\Integration\Pages\PageTerminated \$terminated) {
+    echo json_encode([
+        'success_message' => null,
+        'error_message' => \$terminated->getMessage(),
+    ]);
+}
+PHP;
+
+        file_put_contents($script, $code);
+
+        try {
+            $output = [];
+            $exitCode = 0;
+            exec(escapeshellarg(PHP_BINARY) . ' ' . escapeshellarg($script), $output, $exitCode);
+
+            return [
+                'output' => implode("\n", $output),
+                'exit_code' => $exitCode,
+            ];
+        } finally {
+            @unlink($script);
+            @unlink($stubDir . '/email.php');
+            @unlink($stubDir . '/review.php');
+            @rmdir($stubDir);
+        }
+    }
+}

--- a/tests/Integration/Pages/ProfilePageTest.php
+++ b/tests/Integration/Pages/ProfilePageTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Tests\Integration\Pages;
+
+
+
+
+class ProfilePageTest extends PageTestCase
+{
+    public function testProfilePageBuildsRepositoryUserForm()
+    {
+        $user = $this->createPageUser();
+        $this->setUpPageRuntime('profile', $user);
+
+        $this->runPage('profile');
+
+        $this->assertNotNull($GLOBALS['form']);
+        $this->assertTrue($GLOBALS['form']->has('repository_user'));
+        $this->assertTrue($GLOBALS['form']->has('submit'));
+        $this->assertNull($GLOBALS['info_box']);
+    }
+
+    public function testProfilePageDisplaysValidRepositoryUserInfo()
+    {
+        $oldClient = $GLOBALS['github_client'] ?? null;
+        $GLOBALS['github_client'] = $this->mockGitHubUserClient();
+
+        $user = $this->createPageUser();
+        $user->repository_user = 'github:johnsmith';
+        $this->setUpPageRuntime('profile', $user);
+
+        try {
+            $this->runPage('profile');
+
+            $this->assertSame('User data', $GLOBALS['info_box']['title']);
+            $this->assertSame('github', $GLOBALS['info_box']['rows']['Platform']);
+            $this->assertSame('Johnsmith User', $GLOBALS['info_box']['rows']['Name']);
+            $this->assertSame('johnsmith@example.com', $GLOBALS['info_box']['rows']['Email']);
+            $this->assertSame('https://github.com/johnsmith', $GLOBALS['info_box']['rows']['Username']['url']);
+        } finally {
+            $GLOBALS['github_client'] = $oldClient;
+        }
+    }
+
+    public function testProfilePageTerminatesForInvalidRepositoryUser()
+    {
+        $oldClient = $GLOBALS['github_client'] ?? null;
+        $GLOBALS['github_client'] = new class {
+            public function api($endpoint) {
+                return new class {
+                    public function show($username) {
+                        throw new \Github\Exception\RuntimeException('Not Found');
+                    }
+                };
+            }
+        };
+
+        $user = $this->createPageUser();
+        $user->repository_user = 'github:missing';
+        $this->setUpPageRuntime('profile', $user);
+
+        try {
+            $this->expectException(PageTerminated::class);
+            $this->expectExceptionMessage('User not found');
+            $this->runPage('profile');
+        } finally {
+            $GLOBALS['github_client'] = $oldClient;
+        }
+    }
+
+    private function mockGitHubUserClient(): object
+    {
+        return new class {
+            public function api($endpoint) {
+                return new class {
+                    public function show($username) {
+                        return [
+                            'login' => $username,
+                            'name' => ucfirst($username) . ' User',
+                            'email' => $username . '@example.com',
+                            'company' => 'Tech Company',
+                            'location' => 'Lisbon, Portugal',
+                        ];
+                    }
+                };
+            }
+        };
+    }
+}

--- a/tests/Integration/Pages/ReportPageTest.php
+++ b/tests/Integration/Pages/ReportPageTest.php
@@ -1,0 +1,334 @@
+<?php
+
+namespace Tests\Integration\Pages;
+
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\HttpFoundation\Request;
+
+
+
+class ReportPageTest extends PageTestCase
+{
+    public function testReportPageTerminatesWhenStudentHasNoGroup()
+    {
+        $year = get_current_year();
+        $deadline = new \Deadline($year);
+        $deadline->final_report = new \DateTimeImmutable('+1 day');
+
+        $oldEntityManager = $this->mockReportEntityManager($deadline);
+
+        try {
+            $this->setUpPageRuntime(
+                'report',
+                $this->createPageUser('ist9800', 'No Group Student', ROLE_STUDENT)
+            );
+
+            $this->expectException(PageTerminated::class);
+            $this->expectExceptionMessage('Student is not in a group');
+            $this->runPage('report');
+        } finally {
+            $GLOBALS['entityManager'] = $oldEntityManager;
+        }
+    }
+
+    public function testReportPageBuildsStudentUploadFormTableAndEvalBox()
+    {
+        $year = get_current_year();
+        $student = $this->createPageUser('ist9801', 'Report Student', ROLE_STUDENT);
+        $group = $this->createGroup(31, $year, [$student]);
+        $group->hash_final_report = 'reporthash31';
+        $group->allow_modifications_date = new \DateTimeImmutable('+2 days');
+
+        $deadline = new \Deadline($year);
+        $deadline->final_report = new \DateTimeImmutable('+1 day');
+
+        $oldEntityManager = $this->mockReportEntityManager($deadline);
+
+        try {
+            $this->setUpPageRuntime('report', $student);
+            $this->runPage('report');
+
+            $this->assertSame(
+                'You can submit this form multiple times until the deadline. Only the last submission will be considered.',
+                $GLOBALS['info_message']
+            );
+            $this->assertNotNull($GLOBALS['form']);
+            $this->assertTrue($GLOBALS['form']->has('file'));
+            $this->assertTrue($GLOBALS['form']->has('submit'));
+
+            $this->assertSame(
+                [
+                    [
+                        'Group' => 31,
+                        'PDF' => [
+                            'label' => 'link',
+                            'url' => 'index.php?download=' . $group->id . '&page=report',
+                        ],
+                    ],
+                ],
+                $GLOBALS['table']
+            );
+            $this->assertSame(
+                'index.php?download=' . $group->id . '&page=report',
+                $GLOBALS['embed_file']
+            );
+            $this->assertCount(1, $GLOBALS['__page_test_eval_boxes']);
+            $this->assertSame('report', $GLOBALS['__page_test_eval_boxes'][0]['page']);
+            $this->assertSame($group, $GLOBALS['__page_test_eval_boxes'][0]['group']);
+        } finally {
+            $GLOBALS['entityManager'] = $oldEntityManager;
+        }
+    }
+
+    public function testReportPageUploadsPdfAndStoresFinalReportHash()
+    {
+        $year = get_current_year();
+        $student = $this->createPageUser('ist9802', 'Upload Student', ROLE_STUDENT);
+        $group = $this->createGroup(32, $year, [$student]);
+        $group->allow_modifications_date = new \DateTimeImmutable('+2 days');
+
+        $deadline = new \Deadline($year);
+        $deadline->final_report = new \DateTimeImmutable('+1 day');
+
+        $oldEntityManager = $this->mockReportEntityManager($deadline);
+        [$file, $tmpPath, $expectedHash] = $this->createUploadedPdf();
+        $uploadedPath = $this->uploadPath($expectedHash);
+
+        try {
+            $this->setUpPageRuntime(
+                'report',
+                $student,
+                'POST',
+                [],
+                [
+                    'form' => [
+                        'submit' => '',
+                    ],
+                ]
+            );
+
+            global $request;
+            $request = Request::create(
+                '/index.php?page=report',
+                'POST',
+                $_POST,
+                [],
+                ['form' => ['file' => $file]]
+            );
+
+            $this->runPage('report');
+
+            $this->assertSame('File uploaded successfully!', $GLOBALS['success_message']);
+            $this->assertSame($expectedHash, $group->hash_final_report);
+            $this->assertFileExists($uploadedPath);
+            $this->assertSame(
+                'index.php?download=' . $group->id . '&page=report',
+                $GLOBALS['embed_file']
+            );
+        } finally {
+            $GLOBALS['entityManager'] = $oldEntityManager;
+            if (file_exists($tmpPath)) {
+                @unlink($tmpPath);
+            }
+            if (file_exists($uploadedPath)) {
+                @unlink($uploadedPath);
+            }
+        }
+    }
+
+    public function testReportPageUsesFilteredGroupsForStaffAndEmbedsSinglePdf()
+    {
+        $year = get_current_year();
+        $prof = $this->createPageUser('ist9803', 'Professor Report', ROLE_PROF);
+        $student = $this->createPageUser('ist9804', 'Grouped Student', ROLE_STUDENT);
+        $group = $this->createGroup(33, $year, [$student]);
+        $group->hash_final_report = 'reporthash33';
+
+        $deadline = new \Deadline($year);
+        $deadline->final_report = new \DateTimeImmutable('-1 day');
+
+        $oldEntityManager = $this->mockReportEntityManager($deadline);
+        $GLOBALS['__page_test_filter_result'] = [$group];
+
+        try {
+            $this->setUpPageRuntime('report', $prof);
+            $this->runPage('report');
+
+            $this->assertNull($GLOBALS['form']);
+            $this->assertSame(
+                [
+                    [
+                        'Group' => 33,
+                        'PDF' => [
+                            'label' => 'link',
+                            'url' => 'index.php?download=' . $group->id . '&page=report',
+                        ],
+                    ],
+                ],
+                $GLOBALS['table']
+            );
+            $this->assertSame(
+                'index.php?download=' . $group->id . '&page=report',
+                $GLOBALS['embed_file']
+            );
+            $this->assertCount(1, $GLOBALS['__page_test_eval_boxes']);
+            $this->assertSame($group, $GLOBALS['__page_test_eval_boxes'][0]['group']);
+        } finally {
+            $GLOBALS['entityManager'] = $oldEntityManager;
+        }
+    }
+
+    public function testReportPageDownloadRejectsWithoutPermissions()
+    {
+        $result = $this->runReportDownloadScript(false);
+
+        $this->assertSame(0, $result['exit_code']);
+        $this->assertSame('No permissions', $result['output']);
+    }
+
+    public function testReportPageDownloadOutputsPdfContentWhenAllowed()
+    {
+        $content = "%PDF-1.4\nreport test\n%%EOF\n";
+        $hash = sha1($content);
+        $path = $this->uploadPath($hash);
+        file_put_contents($path, $content);
+
+        try {
+            $result = $this->runReportDownloadScript(true, $hash);
+
+            $this->assertSame(0, $result['exit_code']);
+            $this->assertSame(rtrim($content, "\n"), $result['output']);
+        } finally {
+            if (file_exists($path)) {
+                @unlink($path);
+            }
+        }
+    }
+
+    private function createGroup(int $number, int $year, array $students): \ProjGroup
+    {
+        return $this->createPageGroup(
+            $number,
+            $year,
+            $students,
+            groupId: $number * 100,
+            shiftId: $number * 10
+        );
+    }
+
+    private function mockReportEntityManager(
+        \Deadline $deadline,
+        ?\ProjGroup $downloadGroup = null
+    ): mixed {
+        $oldEntityManager = $GLOBALS['entityManager'] ?? null;
+        $GLOBALS['entityManager'] = new class($deadline, $downloadGroup) {
+            public function __construct(
+                private \Deadline $deadline,
+                private ?\ProjGroup $downloadGroup
+            ) {}
+
+            public function find(string $entity, $id): mixed
+            {
+                if ($entity === 'Deadline') {
+                    return $this->deadline;
+                }
+
+                if ($entity === 'ProjGroup') {
+                    return $this->downloadGroup;
+                }
+
+                return null;
+            }
+
+            public function persist($obj): void
+            {
+            }
+
+            public function flush(): void
+            {
+            }
+        };
+
+        return $oldEntityManager;
+    }
+
+    private function createUploadedPdf(): array
+    {
+        $path = tempnam(sys_get_temp_dir(), 'pic1_report_pdf_');
+        $contents = "%PDF-1.4\n1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n2 0 obj\n<< /Type /Pages /Count 0 >>\nendobj\ntrailer\n<< /Root 1 0 R >>\n%%EOF\n";
+        file_put_contents($path, $contents);
+
+        return [
+            new UploadedFile($path, 'report.pdf', 'application/pdf', null, true),
+            $path,
+            sha1($contents),
+        ];
+    }
+
+    private function uploadPath(string $hash): string
+    {
+        return dirname(__DIR__, 3) . '/uploads/' . $hash;
+    }
+
+    private function runReportDownloadScript(bool $allowed, string $hash = 'downloadhash'): array
+    {
+        $script = sys_get_temp_dir() . '/pic1_report_' . bin2hex(random_bytes(4)) . '.php';
+        $bootstrap = var_export(dirname(__DIR__, 3) . '/tests/bootstrap.php', true);
+        $pageTestCase = var_export(dirname(__DIR__) . '/Pages/PageTestCase.php', true);
+        $page = var_export(dirname(__DIR__, 3) . '/pages/report.php', true);
+        $year = get_current_year();
+        $userRole = $allowed ? 'ROLE_PROF' : 'ROLE_TA';
+        $shiftProfAssignment = $allowed
+            ? '$shift->prof = $GLOBALS[\'__page_test_user\'];'
+            : '$shift->prof = new User(\'ist9910\', \'Other Professor\', \'other@example.com\', \'\', ROLE_PROF, false);';
+
+        $code = <<<PHP
+<?php
+require $bootstrap;
+require $pageTestCase;
+\$_SERVER['HTTP_HOST'] = 'localhost';
+\$_GET = ['page' => 'report', 'download' => 3300];
+\$_POST = [];
+\$_REQUEST = \$_GET;
+\$GLOBALS['page'] = 'report';
+\$GLOBALS['__page_test_user'] = new User('ist9999', 'Download User', 'ist9999@example.com', '', $userRole, false);
+\$GLOBALS['entityManager'] = new class {
+    public function find(string \$entity, \$id): mixed
+    {
+        if (\$entity === 'Deadline') {
+            \$deadline = new Deadline($year);
+            \$deadline->final_report = new DateTimeImmutable('+1 day');
+            return \$deadline;
+        }
+
+        if (\$entity === 'ProjGroup') {
+            \$shift = new Shift('T1', $year);
+            $shiftProfAssignment
+            \$group = new ProjGroup(33, $year, \$shift);
+            \$group->id = 3300;
+            \$group->hash_final_report = '$hash';
+            return \$group;
+        }
+
+        return null;
+    }
+};
+require $page;
+PHP;
+
+        file_put_contents($script, $code);
+
+        try {
+            $output = [];
+            $exitCode = 0;
+            exec(escapeshellarg(PHP_BINARY) . ' ' . escapeshellarg($script), $output, $exitCode);
+
+            return [
+                'output' => implode("\n", $output),
+                'exit_code' => $exitCode,
+            ];
+        } finally {
+            @unlink($script);
+        }
+    }
+}

--- a/tests/Integration/Pages/RmPatchPageTest.php
+++ b/tests/Integration/Pages/RmPatchPageTest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Tests\Integration\Pages;
+
+use Tests\Mocks\FakePatch;
+require_once dirname(__DIR__, 3) . '/entities/Patch.php';
+
+class RmPatchPageTest extends PageTestCase
+{
+    public function testRmPatchPageBuildsConfirmationLink()
+    {
+        $patch = $this->createPatch();
+        $oldEntityManager = $this->mockRmPatchEntityManager($patch);
+
+        try {
+            $prof = $this->createPageUser('ist9960', 'Professor Remove', ROLE_PROF);
+            $this->setUpPageRuntime('rmpatch', $prof, 'GET', ['id' => $patch->id]);
+            $this->runPage('rmpatch');
+
+            $prompt = array_key_first($GLOBALS['confirm']);
+            $this->assertStringContainsString('delete patch 9301', $prompt);
+            $this->assertSame(
+                'index.php?id=9301&sure=1&page=rmpatch',
+                $GLOBALS['confirm'][$prompt]['url']
+            );
+        } finally {
+            $GLOBALS['entityManager'] = $oldEntityManager;
+        }
+    }
+
+    public function testRmPatchPageDeletesPatchWhenConfirmed()
+    {
+        $patch = $this->createPatch();
+        $oldEntityManager = $this->mockRmPatchEntityManager($patch);
+
+        try {
+            $prof = $this->createPageUser('ist9961', 'Professor Remove', ROLE_PROF);
+            $this->setUpPageRuntime('rmpatch', $prof, 'GET', ['id' => $patch->id, 'sure' => 1]);
+            $this->runPage('rmpatch');
+
+            $this->assertSame('Patch deleted', $GLOBALS['success_message']);
+            $this->assertSame($patch, $GLOBALS['entityManager']->removed[0] ?? null);
+            $this->assertSame(1, $GLOBALS['entityManager']->flushCount);
+        } finally {
+            $GLOBALS['entityManager'] = $oldEntityManager;
+        }
+    }
+
+    private function createPatch(): \Patch
+    {
+        $student = $this->createPageUser('ist9962', 'Patch Student', ROLE_STUDENT);
+        $shift = new \Shift('T1', get_current_year());
+        $group = new \ProjGroup(93, get_current_year(), $shift);
+        $group->id = 9300;
+        $group->addStudent($student);
+
+        $patch = new FakePatch(
+            patchOrigin: 'owner:repo:feature-branch',
+            patchText: '',
+            branchHash: 'hash',
+            computedLinesAdded: 0,
+            computedLinesDeleted: 0,
+            computedFilesModified: 0,
+            patchUrl: 'https://github.com/owner/repo/tree/feature-branch',
+            commitUrlBase: ''
+        );
+
+        $patch->id = 9301;
+        $patch->group = $group;
+        $patch->status = \PatchStatus::WaitingReview;
+        $patch->type = \PatchType::Feature;
+        $patch->lines_added = 0;
+        $patch->lines_deleted = 0;
+        $patch->files_modified = 0;
+        $patch->comments->add(new \PatchComment($patch, 'Initial patch', $student));
+
+        return $patch;
+    }
+
+    private function mockRmPatchEntityManager(\Patch $patch): mixed
+    {
+        $oldEntityManager = $GLOBALS['entityManager'] ?? null;
+        $GLOBALS['entityManager'] = new class($patch) {
+            public array $removed = [];
+            public int $flushCount = 0;
+
+            public function __construct(private \Patch $patch) {}
+
+            public function find(string $entity, $id): mixed
+            {
+                if ($entity === 'Patch' && $id === $this->patch->id) {
+                    return $this->patch;
+                }
+
+                return null;
+            }
+
+            public function remove($obj): void
+            {
+                $this->removed[] = $obj;
+            }
+
+            public function flush(): void
+            {
+                $this->flushCount++;
+            }
+        };
+
+        return $oldEntityManager;
+    }
+}

--- a/tests/Integration/Pages/ShiftsPageTest.php
+++ b/tests/Integration/Pages/ShiftsPageTest.php
@@ -1,0 +1,224 @@
+<?php
+
+namespace Tests\Integration\Pages;
+
+
+
+class ShiftsPageTest extends PageTestCase
+{
+    public function testShiftsPageBuildsChoiceFormForCurrentYearShifts()
+    {
+        $ta = $this->createPageUser('ist9100', 'Taylor Assistant', ROLE_TA);
+        $prof = $this->createPageUser('ist9101', 'Professor Example', ROLE_PROF);
+        $shift1 = $this->createShift(11, 'T1', $ta);
+        $shift2 = $this->createShift(12, 'T2', null);
+
+        $oldEntityManager = $this->mockShiftsEntityManager([$shift1, $shift2], [$ta, $prof], []);
+
+        try {
+            $this->setUpPageRuntime(
+                'shifts',
+                $this->createPageUser('ist9102', 'Professor Admin', ROLE_PROF)
+            );
+            $this->runPage('shifts');
+
+            $this->assertSame(get_current_year(), $GLOBALS['__page_test_shifts_year']);
+            $this->assertNotNull($GLOBALS['form']);
+            $this->assertTrue($GLOBALS['form']->has('shift_11'));
+            $this->assertTrue($GLOBALS['form']->has('shift_12'));
+            $this->assertTrue($GLOBALS['form']->has('submit'));
+            $this->assertSame('T1', $GLOBALS['form']->get('shift_11')->getConfig()->getOption('label'));
+            $this->assertSame('T2', $GLOBALS['form']->get('shift_12')->getConfig()->getOption('label'));
+            $this->assertSame('ist9100', $GLOBALS['form']->get('shift_11')->getData());
+            $this->assertNull($GLOBALS['form']->get('shift_12')->getData());
+            $this->assertNull($GLOBALS['success_message']);
+        } finally {
+            $GLOBALS['entityManager'] = $oldEntityManager;
+        }
+    }
+
+    public function testShiftsPageAssignsSelectedProfessorsAndTas()
+    {
+        $sudo = $this->createPageUser('ist9200', 'Sudo User', ROLE_SUDO);
+        $prof = $this->createPageUser('ist9201', 'Professor Example', ROLE_PROF);
+        $ta = $this->createPageUser('ist9202', 'Taylor Assistant', ROLE_TA);
+        $shift1 = $this->createShift(21, 'L1', null);
+        $shift2 = $this->createShift(22, 'L2', $prof);
+
+        $oldEntityManager = $this->mockShiftsEntityManager(
+            [$shift1, $shift2],
+            [$prof, $ta],
+            [
+                'ist9201' => $prof,
+                'ist9202' => $ta,
+            ]
+        );
+
+        try {
+            $this->setUpPageRuntime(
+                'shifts',
+                $sudo,
+                'POST',
+                [],
+                [
+                    'form' => [
+                        'shift_21' => 'ist9202',
+                        'shift_22' => 'ist9201',
+                        'submit' => '',
+                    ],
+                ]
+            );
+            $this->runPage('shifts');
+
+            $this->assertSame($ta, $shift1->prof);
+            $this->assertSame($prof, $shift2->prof);
+            $this->assertSame('Saved!', $GLOBALS['success_message']);
+        } finally {
+            $GLOBALS['entityManager'] = $oldEntityManager;
+        }
+    }
+
+    public function testShiftsPageRejectsUnknownOrNonTaSelection()
+    {
+        $result = $this->runShiftsScriptWithUnknownUser();
+
+        $this->assertSame(0, $result['exit_code']);
+        $this->assertSame('Unknown user', $result['output']);
+    }
+
+    private function createShift(int $id, string $name, ?\User $prof): \Shift
+    {
+        $shift = new \Shift($name, get_current_year());
+        $shift->id = $id;
+        $shift->prof = $prof;
+        return $shift;
+    }
+
+    private function mockShiftsEntityManager(array $shifts, array $eligibleUsers, array $usersById): mixed
+    {
+        $oldEntityManager = $GLOBALS['entityManager'] ?? null;
+        $GLOBALS['entityManager'] = new class($shifts, $eligibleUsers, $usersById) {
+            public function __construct(
+                private array $shifts,
+                private array $eligibleUsers,
+                private array $usersById
+            ) {}
+
+            public function find(string $entity, $id): mixed
+            {
+                if ($entity === 'User') {
+                    return $this->usersById[$id] ?? null;
+                }
+
+                return null;
+            }
+
+            public function getRepository(string $entity): object
+            {
+                if ($entity === 'Shift') {
+                    return new class($this->shifts) {
+                        public function __construct(private array $shifts) {}
+                        public function findByYear($year, $order): array
+                        {
+                            $GLOBALS['__page_test_shifts_year'] = $year;
+                            return $this->shifts;
+                        }
+                    };
+                }
+
+                if ($entity === 'User') {
+                    return new class($this->eligibleUsers) {
+                        public function __construct(private array $users) {}
+                        public function findByRole($roles, $order): array
+                        {
+                            return $this->users;
+                        }
+                    };
+                }
+
+                throw new \RuntimeException("Unexpected repository lookup: $entity");
+            }
+        };
+
+        return $oldEntityManager;
+    }
+
+    private function runShiftsScriptWithUnknownUser(): array
+    {
+        $script = sys_get_temp_dir() . '/pic1_shifts_' . bin2hex(random_bytes(4)) . '.php';
+        $bootstrap = var_export(dirname(__DIR__, 3) . '/tests/bootstrap.php', true);
+        $page = var_export(dirname(__DIR__, 3) . '/pages/shifts.php', true);
+        $year = get_current_year();
+
+        $code = <<<PHP
+<?php
+require $bootstrap;
+\$_SERVER['HTTP_HOST'] = 'localhost';
+\$_GET = ['page' => 'shifts'];
+\$_POST = [
+    'form' => [
+        'shift_31' => 'ist9301',
+        'submit' => '',
+    ],
+];
+\$_REQUEST = \$_GET + \$_POST;
+\$request = Symfony\Component\HttpFoundation\Request::create('/index.php?page=shifts', 'POST', \$_POST);
+\$formFactory = Symfony\Component\Form\Forms::createFormFactoryBuilder()
+    ->addExtension(new Symfony\Component\Form\Extension\HttpFoundation\HttpFoundationExtension())
+    ->getFormFactory();
+\$GLOBALS['entityManager'] = new class {
+    public function find(string \$entity, \$id): mixed
+    {
+        if (\$entity === 'User') {
+            return new User('ist9301', 'Student Choice', 'ist9301@example.com', '', ROLE_STUDENT, false);
+        }
+        return null;
+    }
+
+    public function getRepository(string \$entity): object
+    {
+        if (\$entity === 'Shift') {
+            return new class {
+                public function findByYear(\$year, \$order): array
+                {
+                    \$shift = new Shift('T1', $year);
+                    \$shift->id = 31;
+                    \$shift->prof = null;
+                    return [\$shift];
+                }
+            };
+        }
+
+        if (\$entity === 'User') {
+            return new class {
+                public function findByRole(\$roles, \$order): array
+                {
+                    return [
+                        new User('ist9301', 'Professor Example', 'ist9301@example.com', '', ROLE_PROF, false),
+                    ];
+                }
+            };
+        }
+
+        throw new RuntimeException('Unexpected repository lookup');
+    }
+};
+require $page;
+PHP;
+
+        file_put_contents($script, $code);
+
+        try {
+            $output = [];
+            $exitCode = 0;
+            exec(escapeshellarg(PHP_BINARY) . ' ' . escapeshellarg($script), $output, $exitCode);
+
+            return [
+                'output' => implode("\n", $output),
+                'exit_code' => $exitCode,
+            ];
+        } finally {
+            @unlink($script);
+        }
+    }
+}

--- a/tests/Integration/SessionAuthenticationIntegrationTest.php
+++ b/tests/Integration/SessionAuthenticationIntegrationTest.php
@@ -1,0 +1,339 @@
+<?php
+
+namespace Tests\Integration;
+
+use Tests\Integration\Base\IntegrationTestCase;
+
+/**
+ * Integration tests for Session and Authentication workflows
+ * 
+ * Tests the interaction between:
+ * - User (authenticated)
+ * - Session (active session)
+ * - User permissions
+ * - Session lifecycle
+ */
+class SessionAuthenticationIntegrationTest extends IntegrationTestCase
+{
+    private \User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Create test user
+        $this->user = new \User(
+            username: 'testuser',
+            name: 'Test User',
+            email: 'test@example.com',
+            photo: '',
+            role: ROLE_STUDENT,
+            dummy: false
+        );
+    }
+
+    /**
+     * Test user login creates session
+     * 
+     * Workflow:
+     * 1. User provides credentials
+     * 2. Credentials authenticated
+     * 3. Session created for user
+     * 4. Session assigned unique ID
+     */
+    public function testUserLoginCreatesSession()
+    {
+        $session = new \Session($this->user);
+
+        // Verify session is created and linked to user
+        $this->assertNotNull($session->id);
+        $this->assertEquals($this->user, $session->user);
+        $this->assertTrue($session->isFresh());
+    }
+
+    /**
+     * Test session is fresh on creation
+     * 
+     * Workflow:
+     * 1. Create new session
+     * 2. Check if session is fresh
+     * 3. Verify expiration is in future
+     */
+    public function testSessionFreshnessOnCreation()
+    {
+        $session = new \Session($this->user);
+
+        // Session should be fresh immediately after creation
+        $this->assertTrue($session->isFresh());
+        $this->assertGreaterThan(new \DateTimeImmutable(), $session->expires);
+    }
+
+    /**
+     * Test session expiration in 90 days
+     * 
+     * Workflow:
+     * 1. Create session at time T
+     * 2. Calculate expected expiration (T + 90 days)
+     * 3. Verify session expires at expected time
+     */
+    public function testSessionExpiresIn90Days()
+    {
+        $now = new \DateTimeImmutable();
+        $session = new \Session($this->user);
+        $expectedExpiration = $now->add(new \DateInterval('P90D'));
+
+        // Session should expire in approximately 90 days
+        $diff = $session->expires->getTimestamp() - $expectedExpiration->getTimestamp();
+        $this->assertLessThan(2, abs($diff));  // Within 2 seconds
+    }
+
+    /**
+     * Test each user gets unique session
+     * 
+     * Workflow:
+     * 1. User A creates session
+     * 2. User B creates session
+     * 3. Sessions have different IDs
+     * 4. Each session belongs to correct user
+     */
+    public function testEachUserGetUniqueSessions()
+    {
+        $user1 = new \User('user1', 'User 1', 'user1@example.com', '', ROLE_STUDENT, false);
+        $user2 = new \User('user2', 'User 2', 'user2@example.com', '', ROLE_STUDENT, false);
+
+        $session1 = new \Session($user1);
+        $session2 = new \Session($user2);
+
+        // Sessions should be different
+        $this->assertNotEquals($session1->id, $session2->id);
+        $this->assertEquals('user1', $session1->user->id);
+        $this->assertEquals('user2', $session2->user->id);
+    }
+
+    /**
+     * Test user can have multiple active sessions
+     * 
+     * Workflow:
+     * 1. User creates first session (login on device A)
+     * 2. User creates second session (login on device B)
+     * 3. Both sessions are valid and independent
+     * 4. User can switch between sessions
+     */
+    public function testUserCanHaveMultipleSessions()
+    {
+        $session1 = new \Session($this->user);
+        $session2 = new \Session($this->user);
+        $session3 = new \Session($this->user);
+
+        // All sessions should be different
+        $this->assertNotEquals($session1->id, $session2->id);
+        $this->assertNotEquals($session2->id, $session3->id);
+        $this->assertNotEquals($session1->id, $session3->id);
+
+        // All sessions belong to same user
+        $this->assertEquals($this->user->id, $session1->user->id);
+        $this->assertEquals($this->user->id, $session2->user->id);
+        $this->assertEquals($this->user->id, $session3->user->id);
+
+        // All sessions are fresh
+        $this->assertTrue($session1->isFresh());
+        $this->assertTrue($session2->isFresh());
+        $this->assertTrue($session3->isFresh());
+    }
+
+    /**
+     * Test session ID is cryptographically secure
+     * 
+     * Workflow:
+     * 1. Create multiple sessions
+     * 2. Verify all IDs are unique (extremely low collision probability)
+     * 3. Verify ID format is valid hex
+     */
+    public function testSessionIdIsSecure()
+    {
+        $ids = [];
+        for ($i = 0; $i < 100; $i++) {
+            $session = new \Session($this->user);
+            $ids[] = $session->id;
+
+            // Verify ID is hex string
+            $this->assertMatchesRegularExpression('/^[a-f0-9]{32}$/', $session->id);
+        }
+
+        // All IDs should be unique
+        $uniqueIds = array_unique($ids);
+        $this->assertCount(100, $uniqueIds);
+    }
+
+    /**
+     * Test session retrieval by ID
+     * 
+     * Workflow:
+     * 1. Create session and get its ID
+     * 2. Use ID to retrieve session
+     * 3. Verify retrieved session matches original
+     * 4. Verify user is accessible through session
+     */
+    /**
+     * Test session retrieval from database by ID
+     * 
+     * Workflow:
+     * 1. Create and insert user into database
+     * 2. Create and insert session into database
+     * 3. Query session back from database by ID
+     * 4. Verify retrieved session matches persisted data
+     * 5. Verify user relationship is intact
+     */
+    public function testSessionRetrievalById()
+    {
+        // Create user in database
+        $userId = 'test_session_' . bin2hex(random_bytes(4));
+        $this->insertTestUser($userId, 'Test Session User');
+        
+        // Create session and insert into database
+        $sessionId = bin2hex(random_bytes(16));
+        $expectedExpiration = new \DateTimeImmutable('+90 days');
+        $this->insertTestSession($sessionId, $userId, $expectedExpiration);
+        
+        // Query session back from database
+        $retrievedSession = $this->getSessionFromDatabase($sessionId);
+        
+        // Verify session exists in database
+        $this->assertNotNull($retrievedSession, 'Session should be retrieved from database');
+        
+        // Verify session ID matches
+        $this->assertEquals($sessionId, $retrievedSession['id']);
+        
+        // Verify user ID matches
+        $this->assertEquals($userId, $retrievedSession['user_id']);
+        
+        // Verify expiration is in the future
+        $expiration = new \DateTimeImmutable($retrievedSession['expires']);
+        $this->assertGreaterThan(new \DateTimeImmutable(), $expiration);
+    }
+
+    public function testSessionPersistenceRejectsUnknownUser()
+    {
+        $this->expectException(\PDOException::class);
+
+        $this->insertTestSession(bin2hex(random_bytes(16)), 'missing-user');
+    }
+
+    /**
+     * Test student accessing their project group through session
+     * 
+     * Workflow:
+     * 1. Student logs in (creates session)
+     * 2. Session carries user identity
+     * 3. User accesses their current project group
+     * 4. Verify student can see group info
+     */
+    public function testStudentAccessesGroupThroughSession()
+    {
+        $student = new \User('student1', 'John Student', 'john@example.com', '', ROLE_STUDENT, false);
+        $session = new \Session($student);
+
+        // Create group and add student (simulating group assignment)
+        $shift = new \Shift('Monday 10:00', 2024);
+
+        $group = new \ProjGroup(1, 2024, $shift);
+        $group->project_name = 'Cool Project';
+        $group->students->add($student);
+
+        // Through session, student can access group
+        $this->assertEquals($student->id, $session->user->id);
+        $this->assertTrue($group->students->contains($session->user));
+    }
+
+    /**
+     * Test professor managing students through authenticated session
+     * 
+     * Workflow:
+     * 1. Professor logs in (creates session)
+     * 2. Professor session identifies them as professor (role check)
+     * 3. Professor can grade student submissions
+     * 4. Grades are attributed to professor
+     */
+    public function testProfessorManagementThroughSession()
+    {
+        $professor = new \User('prof1', 'Prof. Teacher', 'prof@example.com', '', ROLE_PROF, false);
+        $session = new \Session($professor);
+
+        // Verify session user has professor role
+        $this->assertSame(ROLE_PROF, $session->user->role);
+        
+        // Professor can create and grade assignments
+        $milestone = new \Milestone(2024, 'Assignment 1');
+        $milestone->field1 = 'Code Quality';
+        $milestone->range1 = 100;
+
+        // Professor can grade students
+        $student = new \User('student1', 'John', 'john@example.com', '', ROLE_STUDENT, false);
+        $grade = new \Grade();
+        $grade->user = $student;
+        $grade->milestone = $milestone;
+        $grade->field1 = 85;
+
+        // Grades are recorded in context of professor session
+        $this->assertNotNull($grade->user);
+        $this->assertNotNull($grade->milestone);
+    }
+
+    /**
+     * Test session maintenance and persistence across page views
+     * 
+     * Workflow:
+     * 1. User logs in and session is stored in database
+     * 2. User navigates to multiple pages
+     * 3. Session ID remains valid in database
+     * 4. User stays authenticated via session lookup
+     * 5. Session data persists unchanged
+     */
+    public function testSessionMaintenanceAcrossPageViews()
+    {
+        // Create user and session in database
+        $userId = 'test_multipage_' . bin2hex(random_bytes(4));
+        $sessionId = bin2hex(random_bytes(16));
+        $this->insertTestUser($userId, 'Multi-Page User');
+        $this->insertTestSession($sessionId, $userId);
+        
+        $originalSession = $this->getSessionFromDatabase($sessionId);
+        $this->assertNotNull($originalSession);
+        
+        // Simulate accessing multiple pages - session ID should remain in DB
+        $pageOneSession = $this->getSessionFromDatabase($sessionId);
+        $this->assertEquals($originalSession['id'], $pageOneSession['id']);
+        $this->assertEquals($originalSession['user_id'], $pageOneSession['user_id']);
+        
+        // After accessing page 2
+        $pageTwoSession = $this->getSessionFromDatabase($sessionId);
+        $this->assertEquals($originalSession['id'], $pageTwoSession['id']);
+        
+        // Session should still be associated with original user
+        $this->assertEquals($userId, $pageTwoSession['user_id']);
+        
+        // Session data should not have changed
+        $this->assertEquals($originalSession, $pageTwoSession);
+    }
+
+    /**
+     * Test dummy/test user sessions
+     * 
+     * Workflow:
+     * 1. Create session for dummy user
+     * 2. Session is valid but marked as test
+     * 3. Dummy user sessions don't interfere with real users
+     */
+    public function testDummyUserSessions()
+    {
+        $dummyUser = new \User('ist0000001', 'Dummy User', 'dummy@example.com', '', ROLE_STUDENT, true);
+        $session = new \Session($dummyUser);
+
+        // Dummy user session is still valid
+        $this->assertTrue($session->isFresh());
+        $this->assertTrue($session->user->isDummy());
+        
+        // But can be identified as test
+        $this->assertStringStartsWith('ist0000', $session->user->id);
+    }
+}

--- a/tests/Integration/UserProjectGroupIntegrationTest.php
+++ b/tests/Integration/UserProjectGroupIntegrationTest.php
@@ -1,0 +1,239 @@
+<?php
+
+namespace Tests\Integration;
+
+use Tests\Integration\Base\IntegrationTestCase;
+
+/**
+ * Integration tests for User and Project Group workflows
+ * 
+ * Tests the interaction between:
+ * - User entities
+ * - Project Group enrollment
+ * - User role permissions
+ * - User project assignments
+ */
+class UserProjectGroupIntegrationTest extends IntegrationTestCase
+{
+    private \User $student;
+    private \User $professor;
+    private \Shift $testShift;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Create test users
+        $this->student = new \User(
+            username: 'student1',
+            name: 'Alice Student',
+            email: 'alice@example.com',
+            photo: '',
+            role: ROLE_STUDENT,
+            dummy: false
+        );
+
+        $this->professor = new \User(
+            username: 'prof1',
+            name: 'Prof. Teacher',
+            email: 'prof@example.com',
+            photo: '',
+            role: ROLE_PROF,
+            dummy: false
+        );
+
+        // Create test shift
+        $this->testShift = new \Shift('Monday 10:00', 2024);
+    }
+
+    /**
+     * Test user enrollment in project group workflow
+     * 
+     * Workflow:
+     * 1. Create new project group
+     * 2. Add student to group
+     * 3. Verify student is in group
+     * 4. Verify group has student
+     */
+    public function testUserEnrollmentInProjectGroup()
+    {
+        // Create a project group
+        $group = new \ProjGroup(1, 2024, $this->testShift);
+        $group->project_name = 'Awesome Project';
+        $group->project_description = 'An awesome student project';
+        $group->repository = 'https://github.com/example/project';
+
+        // Add student to group
+        $group->students->add($this->student);
+
+        // Verify student is in group
+        $this->assertTrue($group->students->contains($this->student));
+        $this->assertCount(1, $group->students);
+    }
+
+    /**
+     * Test multiple students in same project group
+     * 
+     * Workflow:
+     * 1. Create project group with multiple students
+     * 2. Verify each student is added
+     * 3. Verify group has correct student count
+     */
+    public function testMultipleStudentsInProjectGroup()
+    {
+        $student1 = new \User('user1', 'Student 1', 'user1@example.com', '', ROLE_STUDENT, false);
+        $student2 = new \User('user2', 'Student 2', 'user2@example.com', '', ROLE_STUDENT, false);
+        $student3 = new \User('user3', 'Student 3', 'user3@example.com', '', ROLE_STUDENT, false);
+
+        $group = new \ProjGroup(2, 2024, $this->testShift);
+
+        // Add multiple students
+        $group->students->add($student1);
+        $group->students->add($student2);
+        $group->students->add($student3);
+
+        // Verify all students are in group
+        $this->assertCount(3, $group->students);
+        $this->assertTrue($group->students->contains($student1));
+        $this->assertTrue($group->students->contains($student2));
+        $this->assertTrue($group->students->contains($student3));
+    }
+
+    /**
+     * Test student's current year group retrieval
+     * 
+     * Workflow:
+     * 1. Create multiple groups for same student in different years
+     * 2. Call getGroup() to get current year group
+     * 3. Verify correct group is returned
+     */
+    public function testGetCurrentYearGroup()
+    {
+        $currentYear = get_current_year();
+        $oldGroup = new \ProjGroup(1, $currentYear - 1, $this->testShift);
+        $currentGroup = new \ProjGroup(2, $currentYear, $this->testShift);
+
+        $oldGroup->addStudent($this->student);
+        $currentGroup->addStudent($this->student);
+
+        $this->assertSame($currentGroup, $this->student->getGroup());
+    }
+
+    /**
+     * Test professor can view group details
+     * 
+     * Workflow:
+     * 1. Professor creates project group
+     * 2. Professor assigns students
+     * 3. Professor can view all group members
+     * 4. Professor can view project repository
+     */
+    public function testProfessorManagesProjectGroup()
+    {
+        $group = new \ProjGroup(1, 2024, $this->testShift);
+        $group->project_name = 'Student Project';
+        $group->repository = 'https://github.com/students/project';
+        $group->students = new \Doctrine\Common\Collections\ArrayCollection();
+        $group->students->add($this->student);
+
+        // Professor can view project details
+        $this->assertEquals('Student Project', $group->project_name);
+        $this->assertEquals('https://github.com/students/project', $group->repository);
+        $this->assertCount(1, $group->students);
+    }
+
+    /**
+     * Test project group with repository configuration
+     * 
+     * Workflow:
+     * 1. Create project group with repository URL
+     * 2. Configure CLA/DCO requirements
+     * 3. Verify repository can be referenced
+     */
+    public function testProjectGroupRepositoryConfiguration()
+    {
+        $group = new \ProjGroup(1, 2024, $this->testShift);
+        $group->repository = 'https://github.com/example/project';
+        $group->cla = true;
+        $group->dco = false;
+
+        // Verify repository is set
+        $this->assertNotEmpty($group->repository);
+        $this->assertTrue($group->cla);
+        $this->assertFalse($group->dco);
+    }
+
+    /**
+     * Test student group data persistence
+     * 
+     * Workflow:
+     * 1. Create and populate project group
+     * 2. Retrieve group information
+     * 3. Verify data is consistent
+     */
+    /**
+     * Test group data persistence in database
+     * 
+     * Workflow:
+     * 1. Create shift in database
+     * 2. Create project group in database with properties
+     * 3. Add student user to group
+     * 4. Query group back from database
+     * 5. Verify all properties persisted correctly
+     * 6. Verify student membership is persisted
+     */
+    public function testGroupDataPersistence()
+    {
+        $year = 2024;
+        
+        // Create shift
+        $shiftId = $this->insertTestShift($year, 'Test Shift');
+        
+        // Create student
+        $studentId = 'test_group_' . bin2hex(random_bytes(4));
+        $this->insertTestUser($studentId, 'Group Test Student');
+        
+        // Create project group
+        $groupId = $this->insertTestGroup(5, $year, $shiftId, 'Test Project');
+        
+        // Add student to group
+        $this->insertGroupMembership($groupId, $studentId);
+        
+        // Query group back from database
+        $retrievedGroup = $this->getGroupFromDatabase($groupId);
+        
+        // Verify group exists and data persisted
+        $this->assertNotNull($retrievedGroup);
+        $this->assertEquals(5, $retrievedGroup['group_number']);
+        $this->assertEquals($year, $retrievedGroup['year']);
+        $this->assertEquals('Test Project', $retrievedGroup['project_name']);
+        $this->assertEquals($shiftId, $retrievedGroup['shift_id']);
+        
+        // Verify student membership persisted
+        $members = $this->getGroupMembersFromDatabase($groupId);
+        $this->assertCount(1, $members);
+        $this->assertContains($studentId, $members);
+    }
+
+    /**
+     * Test user retrieves their current group
+     * 
+     * Workflow:
+     * 1. Student is member of group
+     * 2. Student can call getGroup()
+     * 3. Student gets correct current year group
+     * 4. Student can access group project info
+     */
+    public function testStudentRetrievesCurrentGroup()
+    {
+        $currentYear = get_current_year();
+        $group = new \ProjGroup(7, $currentYear, $this->testShift);
+        $group->project_name = 'Current Project';
+        $group->addStudent($this->student);
+
+        $currentGroup = $this->student->getGroup();
+
+        $this->assertSame($group, $currentGroup);
+        $this->assertEquals('Current Project', $currentGroup->project_name);
+    }
+}

--- a/tests/Mocks/FakePatch.php
+++ b/tests/Mocks/FakePatch.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Tests\Mocks;
+
+class FakePatch extends \Patch
+{
+    public function __construct(
+        private bool $valid = true,
+        private string $patchBranch = 'feature-branch',
+        private string $patchOrigin = 'origin/feature-branch',
+        private array $patchCommits = [],
+        private array $patchDiff = [],
+        private string $patchText = 'patch content',
+        private string $branchHash = 'abc123',
+        private int $computedLinesAdded = 10,
+        private int $computedLinesDeleted = 5,
+        private int $computedFilesModified = 3,
+        private string $patchUrl = 'https://github.com/test',
+        private string $commitUrlBase = 'https://github.com/test/commit/',
+        private ?\PullRequest $pullRequest = null,
+        private bool $setsPullRequest = false
+    ) {
+        parent::__construct();
+    }
+
+    public function isValid(): bool
+    {
+        return $this->valid;
+    }
+
+    public function branch(): string
+    {
+        return $this->patchBranch;
+    }
+
+    public function origin(): string
+    {
+        return $this->patchOrigin;
+    }
+
+    public function commits(): array
+    {
+        return $this->patchCommits;
+    }
+
+    public function diff(): array
+    {
+        return $this->patchDiff;
+    }
+
+    public function patch(): string
+    {
+        return $this->patchText;
+    }
+
+    protected function computeBranchHash(): string
+    {
+        return $this->branchHash;
+    }
+
+    protected function computeLinesAdded(): int
+    {
+        return $this->computedLinesAdded;
+    }
+
+    protected function computeLinesDeleted(): int
+    {
+        return $this->computedLinesDeleted;
+    }
+
+    protected function computeFilesModified(): int
+    {
+        return $this->computedFilesModified;
+    }
+
+    public function getPatchURL(): string
+    {
+        return $this->patchUrl;
+    }
+
+    public function getCommitURL(string $hash): string
+    {
+        return $this->commitUrlBase . $hash;
+    }
+
+    public function setPR(\PullRequest $pr)
+    {
+        $this->pullRequest = $pr;
+    }
+
+    public function findAndSetPR(): bool
+    {
+        return $this->setsPullRequest;
+    }
+
+    public function getPR(): ?\PullRequest
+    {
+        return $this->pullRequest;
+    }
+}

--- a/tests/Mocks/FakePullRequest.php
+++ b/tests/Mocks/FakePullRequest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Tests\Mocks;
+
+class FakePullRequest extends \PullRequest
+{
+    public function __construct(
+        private string $pullRequestUrl = 'https://github.com/mockorg/mockrepo/pull/1',
+        private string $branchUrl = 'https://github.com/mockorg/mockrepo/tree/feature-branch',
+        private string $pullRequestOrigin = 'mockorg:mockrepo:feature-branch',
+        private bool $closed = false,
+        private bool $merged = false,
+        private string $merger = '',
+        private ?\DateTimeImmutable $mergedAt = null,
+        private int $addedLines = 0,
+        private int $deletedLines = 0,
+        private int $modifiedFiles = 0,
+        private array $failedJobs = []
+    ) {}
+
+    public function url(): string
+    {
+        return $this->pullRequestUrl;
+    }
+
+    public function branchURL(): string
+    {
+        return $this->branchUrl;
+    }
+
+    public function origin(): string
+    {
+        return $this->pullRequestOrigin;
+    }
+
+    public function isClosed(): bool
+    {
+        return $this->closed;
+    }
+
+    public function wasMerged(): bool
+    {
+        return $this->merged;
+    }
+
+    public function mergedBy(): string
+    {
+        return $this->merger;
+    }
+
+    public function mergeDate(): \DateTimeImmutable
+    {
+        return $this->mergedAt ?? new \DateTimeImmutable();
+    }
+
+    public function linesAdded(): int
+    {
+        return $this->addedLines;
+    }
+
+    public function linesDeleted(): int
+    {
+        return $this->deletedLines;
+    }
+
+    public function filesModified(): int
+    {
+        return $this->modifiedFiles;
+    }
+
+    public function failedCIjobs(string $hash): array
+    {
+        return $this->failedJobs;
+    }
+
+    public function __toString(): string
+    {
+        return $this->pullRequestUrl;
+    }
+}

--- a/tests/Mocks/FakeQueryResultEntityManager.php
+++ b/tests/Mocks/FakeQueryResultEntityManager.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Tests\Mocks;
+
+class FakeQueryResultEntityManager
+{
+    public function __construct(private mixed $result) {}
+
+    public function createQueryBuilder(): FakeQueryResultQueryBuilder
+    {
+        return new FakeQueryResultQueryBuilder($this->result);
+    }
+}
+
+class FakeQueryResultQueryBuilder
+{
+    public function __construct(private mixed $result) {}
+
+    public function from($entity, $alias): self
+    {
+        return $this;
+    }
+
+    public function select($select): self
+    {
+        return $this;
+    }
+
+    public function where($where): self
+    {
+        return $this;
+    }
+
+    public function andWhere($where): self
+    {
+        return $this;
+    }
+
+    public function setParameter($name, $value): self
+    {
+        return $this;
+    }
+
+    public function getQuery(): self
+    {
+        return $this;
+    }
+
+    public function getOneOrNullResult(): mixed
+    {
+        return $this->result;
+    }
+
+    public function getArrayResult(): array
+    {
+        return $this->result;
+    }
+}

--- a/tests/Mocks/MockGitHubClient.php
+++ b/tests/Mocks/MockGitHubClient.php
@@ -1,0 +1,358 @@
+<?php
+
+namespace Tests\Mocks;
+
+/**
+ * Mock GitHub API Client for testing
+ * 
+ * Returns realistic fake data without making real API calls
+ * or exposing credentials
+ */
+class MockGitHubClient {
+    public array $queries = [];
+
+    private ?array $searchResults;
+    private array $languagesByRepository;
+    private array $participationByRepository;
+
+    public function __construct(
+        ?array $searchResults = null,
+        array $languagesByRepository = [],
+        array $participationByRepository = []
+    ) {
+        $this->searchResults = $searchResults;
+        $this->languagesByRepository = $languagesByRepository;
+        $this->participationByRepository = $participationByRepository;
+    }
+
+    public function api($endpoint) {
+        if ($endpoint === 'search') {
+            return new MockSearchAPI($this, $this->searchResults);
+        }
+        if ($endpoint === 'issue') {
+            return new MockIssueAPI();
+        }
+        if ($endpoint === 'repo') {
+            return new MockRepoAPI($this->languagesByRepository, $this->participationByRepository);
+        }
+        if ($endpoint === 'repository') {
+            return new MockRepositoryAPI();
+        }
+        if ($endpoint === 'pr') {
+            return new MockPullRequestAPI();
+        }
+        if ($endpoint === 'user') {
+            return new MockUserAPI();
+        }
+        throw new \Exception("Mock API endpoint not implemented: $endpoint");
+    }
+
+    public function authenticate($token, $login, $method) {
+        // No-op
+    }
+
+    public function setSearchResults(array $results) {
+        $this->searchResults = $results;
+    }
+
+    public function recordQuery(string $query): void {
+        $this->queries[] = $query;
+    }
+}
+
+/**
+ * Mock for repository->branches
+ */
+class MockRepositoryAPI {
+    public function branches($org, $repo, $branch) {
+        // Return mock branch data as expected by GitHubPatch::construct
+        return [
+            'name' => $branch,
+            'commit' => [
+                'url' => "https://api.github.com/repos/$org/$repo/commits/mocksha123",
+                'sha' => 'mocksha123',
+            ],
+        ];
+    }
+}
+
+/**
+ * Mock for repo->commits->compare
+ */
+class MockRepoAPI {
+    public function __construct(
+        private array $languagesByRepository = [],
+        private array $participationByRepository = []
+    ) {}
+
+    public function show($owner, $repo) {
+        return [
+            'id' => 1296269,
+            'name' => $repo,
+            'full_name' => "$owner/$repo",
+            'description' => 'Mock repository for testing',
+            'language' => 'PHP',
+            'stargazers_count' => 1000,
+            'open_issues' => 50,
+            'default_branch' => 'main',
+            'topics' => ['php', 'testing'],
+        ];
+    }
+
+    public function languages($owner, $repo) {
+        $repository = "$owner/$repo";
+        if (array_key_exists($repository, $this->languagesByRepository)) {
+            return $this->languagesByRepository[$repository];
+        }
+
+        return [
+            'PHP' => 50000,
+            'JavaScript' => 30000,
+            'HTML' => 20000,
+        ];
+    }
+
+    public function participation($owner, $repo) {
+        $repository = "$owner/$repo";
+        if (array_key_exists($repository, $this->participationByRepository)) {
+            return $this->participationByRepository[$repository];
+        }
+
+        return [
+            'all' => array_fill(0, 52, 100),
+            'owner' => array_fill(0, 52, 50),
+        ];
+    }
+
+    public function commits() {
+        return new MockCommitsAPI();
+    }
+}
+
+class MockCommitsAPI {
+    public function compare($org, $repo, $srcBranch, $repoBranch, $accept = null) {
+        // If patch accept header, return a string
+        if ($accept === 'application/vnd.github.patch') {
+            return "diff --git a/file1.php b/file1.php\n+Added line\n-Removed line\n";
+        }
+        // Otherwise, return the array structure
+        return [
+            'commits' => [
+                [
+                    'sha' => 'mocksha123',
+                    'author' => [ 'login' => 'mockuser' ],
+                    'commit' => [
+                        'author' => [
+                            'name' => 'Mock User',
+                            'email' => 'ist12345@tecnico.ulisboa.pt',
+                        ],
+                        'message' => 'Mock commit message for testing.',
+                    ],
+                ],
+            ],
+            'files' => [
+                [
+                    'filename' => 'file1.php',
+                    'patch' => "+Added line\n-Removed line\n",
+                    'additions' => 1,
+                    'deletions' => 1,
+                ],
+            ],
+        ];
+    }
+}
+
+/**
+ * Mock search API
+ */
+class MockSearchAPI {
+    private ?array $customResults;
+
+    public function __construct(
+        private MockGitHubClient $client,
+        ?array $customResults = null
+    ) {
+        $this->customResults = $customResults;
+    }
+
+    /**
+     * Mock repositories() search
+     * Returns realistic GitHub repository search results
+     */
+    public function repositories($query, $sort = null, $order = null) {
+        $this->client->recordQuery($query);
+
+        // If custom results were provided, use them even when intentionally empty.
+        if ($this->customResults !== null) {
+            return $this->customResults;
+        }
+
+        // Return default realistic mock data for various keywords
+        if (strpos($query, 'api') !== false) {
+            return $this->getMockApiRepositories();
+        }
+        if (strpos($query, 'test') !== false) {
+            return $this->getMockTestRepositories();
+        }
+        if (strpos($query, 'help') !== false) {
+            return $this->getMockHelpRepositories();
+        }
+
+        // Generic default response
+        return ['items' => []];
+    }
+
+    /**
+     * Mock repositories with "api" keyword
+     */
+    private function getMockApiRepositories() {
+        return [
+            'items' => [
+                [
+                    'full_name' => 'axios/axios',
+                    'description' => 'Promise based HTTP client for the browser and node.js',
+                    'html_url' => 'https://github.com/axios/axios',
+                    'stargazers_count' => 105000,
+                    'open_issues' => 285,
+                    'language' => 'JavaScript',
+                    'topics' => ['api', 'http', 'client', 'rest', 'xhr'],
+                    'pushed_at' => date('c', strtotime('-5 days')),
+                ],
+                [
+                    'full_name' => 'expressjs/express',
+                    'description' => 'Fast, unopinionated, minimalist web framework for node.',
+                    'html_url' => 'https://github.com/expressjs/express',
+                    'stargazers_count' => 65000,
+                    'open_issues' => 150,
+                    'language' => 'JavaScript',
+                    'topics' => ['api', 'web', 'framework', 'rest'],
+                    'pushed_at' => date('c', strtotime('-3 days')),
+                ],
+                [
+                    'full_name' => 'requests/requests',
+                    'description' => 'A simple, yet elegant HTTP library for Python',
+                    'html_url' => 'https://github.com/requests/requests',
+                    'stargazers_count' => 52000,
+                    'open_issues' => 220,
+                    'language' => 'Python',
+                    'topics' => ['api', 'http', 'client', 'requests'],
+                    'pushed_at' => date('c', strtotime('-7 days')),
+                ],
+            ]
+        ];
+    }
+
+    /**
+     * Mock repositories with "test" keyword
+     */
+    private function getMockTestRepositories() {
+        return [
+            'items' => [
+                [
+                    'full_name' => 'jestjs/jest',
+                    'description' => 'Delightful JavaScript Testing Framework',
+                    'html_url' => 'https://github.com/jestjs/jest',
+                    'stargazers_count' => 43000,
+                    'open_issues' => 340,
+                    'language' => 'JavaScript',
+                    'topics' => ['test', 'testing', 'jest', 'javascript'],
+                    'pushed_at' => date('c', strtotime('-2 days')),
+                ],
+                [
+                    'full_name' => 'phpunit/phpunit',
+                    'description' => 'The PHP Unit Testing framework',
+                    'html_url' => 'https://github.com/phpunit/phpunit',
+                    'stargazers_count' => 19000,
+                    'open_issues' => 120,
+                    'language' => 'PHP',
+                    'topics' => ['test', 'testing', 'phpunit', 'framework'],
+                    'pushed_at' => date('c', strtotime('-1 day')),
+                ],
+            ]
+        ];
+    }
+
+    /**
+     * Mock repositories with "help" keyword
+     */
+    private function getMockHelpRepositories() {
+        return [
+            'items' => [
+                [
+                    'full_name' => 'github/docs',
+                    'description' => 'The open-source repo for github.com/docs',
+                    'html_url' => 'https://github.com/github/docs',
+                    'stargazers_count' => 16000,
+                    'open_issues' => 45,
+                    'language' => 'Markdown',
+                    'topics' => ['help', 'documentation', 'github'],
+                    'pushed_at' => date('c', strtotime('-1 day')),
+                ],
+            ]
+        ];
+    }
+}
+
+/**
+ * Mock issue API
+ */
+class MockIssueAPI {
+    public function show($owner, $repo, $number) {
+        return [
+            'number' => $number,
+            'title' => 'Mock Issue #' . $number,
+            'body' => 'This is a mock issue description for testing purposes.',
+            'state' => 'open',
+            'labels' => [['name' => 'bug']],
+            'user' => ['login' => 'testuser'],
+            'created_at' => date('c'),
+            'updated_at' => date('c'),
+        ];
+    }
+
+    public function all($owner, $repo, $params = []) {
+        return [
+            [
+                'number' => 1,
+                'title' => 'First issue',
+                'state' => 'open',
+                'labels' => [['name' => 'good first issue']],
+            ]
+        ];
+    }
+}
+
+/**
+ * Mock user API
+ */
+class MockUserAPI {
+    public function show($username) {
+        return [
+            'login' => $username,
+            'id' => 123456,
+            'name' => ucfirst($username) . ' User',
+            'email' => $username . '@example.com',
+            'company' => 'Tech Company',
+            'location' => 'Lisbon, Portugal',
+            'public_repos' => 15,
+            'followers' => 100,
+            'following' => 50,
+        ];
+    }
+}
+
+/**
+ * Mock pull request API
+ */
+class MockPullRequestAPI {
+    public function all($owner, $repo, $params = []) {
+        return [
+            [
+                'number' => 1,
+                'title' => 'Mock pull request',
+                'state' => 'open',
+                'merged_at' => null,
+            ]
+        ];
+    }
+}

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,66 @@
+# Testing
+
+The test suite uses PHPUnit 11 and is configured in `phpunit.xml`.
+
+## Setup
+
+Install dependencies from the repository root:
+
+```bash
+composer install
+```
+
+## Running Tests
+
+```bash
+# Run all tests with the configured coverage reports
+vendor/bin/phpunit
+
+# Run all tests without generating coverage reports
+./scripts/run-tests-fast.sh
+
+# Run one suite
+vendor/bin/phpunit --testsuite="Unit Tests"
+vendor/bin/phpunit --testsuite="Integration Tests"
+vendor/bin/phpunit --testsuite="End-to-End Tests"
+
+# Run one file or matching tests
+vendor/bin/phpunit tests/Unit/UserTest.php
+vendor/bin/phpunit --filter GitHubUserTest
+```
+
+The end-to-end suite starts a local PHP HTTP server and therefore needs permission to bind to a local port.
+
+## Coverage
+
+Coverage includes application code in `entities/` and `pages/`. A PCOV or Xdebug coverage driver is required.
+
+```bash
+# Generate HTML, Clover XML, and terminal coverage reports
+./scripts/run-coverage.sh
+```
+
+Generated reports are written to `coverage/`; open `coverage/index.html` for the HTML report.
+
+## Layout
+
+```text
+tests/
+|-- bootstrap.php              Shared test initialization
+|-- Unit/                      Isolated domain and GitHub entity tests
+|-- Integration/               Database and page workflow tests
+|-- EndToEnd/                  HTTP-level application tests
+`-- Mocks/                     Test doubles for GitHub and entities
+
+phpunit.xml                    PHPUnit suites and coverage configuration
+scripts/run-tests-fast.sh      Run tests without coverage reports
+scripts/run-coverage.sh        Generate coverage reports
+```
+
+## Test Support
+
+- `tests/Unit/Base/UnitTestCase.php` provides shared unit-test setup.
+- `tests/Integration/Base/IntegrationTestCase.php` prepares integration fixtures and storage.
+- `tests/Integration/Pages/PageTestCase.php` supports page-level workflow tests.
+- `tests/EndToEnd/Base/WebTestCase.php` runs tests through a local web server.
+- `tests/Mocks/` contains reusable test doubles.

--- a/tests/Unit/Base/UnitTestCase.php
+++ b/tests/Unit/Base/UnitTestCase.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Tests\Unit\Base;
+
+use PHPUnit\Framework\TestCase as BaseTestCase;
+
+/**
+ * Base test case class for unit tests
+ * 
+ * Provides common setup and teardown logic
+ */
+abstract class UnitTestCase extends BaseTestCase
+{
+    private array $originalGitHubClients = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->originalGitHubClients as $name => $original) {
+            if ($original['exists']) {
+                $GLOBALS[$name] = $original['value'];
+            } else {
+                unset($GLOBALS[$name]);
+            }
+        }
+        $this->originalGitHubClients = [];
+
+        parent::tearDown();
+    }
+
+    protected function replaceGitHubClient(object $client): object
+    {
+        return $this->replaceGitHubGlobal('github_client', $client);
+    }
+
+    protected function replaceCachedGitHubClient(object $client): object
+    {
+        return $this->replaceGitHubGlobal('github_client_cached', $client);
+    }
+
+    private function replaceGitHubGlobal(string $name, object $client): object
+    {
+        if (!array_key_exists($name, $this->originalGitHubClients)) {
+            $this->originalGitHubClients[$name] = [
+                'exists' => array_key_exists($name, $GLOBALS),
+                'value' => $GLOBALS[$name] ?? null,
+            ];
+        }
+
+        $GLOBALS[$name] = $client;
+
+        return $client;
+    }
+}

--- a/tests/Unit/DeadlineTest.php
+++ b/tests/Unit/DeadlineTest.php
@@ -1,0 +1,181 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\Unit\Base\UnitTestCase;
+
+
+
+/**
+ * Test suite for Deadline entity
+ * 
+ * Tests deadline dates, active status checking for each milestone
+ */
+class DeadlineTest extends UnitTestCase
+{
+    private \Deadline $deadline;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->deadline = new \Deadline(2024);
+    }
+
+    /**
+     * Test that deadline can be instantiated with year
+     */
+    public function testDeadlineCanBeCreated()
+    {
+        $this->assertInstanceOf(\Deadline::class, $this->deadline);
+        $this->assertEquals(2024, $this->deadline->year);
+    }
+
+    /**
+     * Test deadline has all required date fields
+     */
+    public function testDeadlineHasAllDateFields()
+    {
+        $this->assertInstanceOf(\DateTimeImmutable::class, $this->deadline->proj_proposal);
+        $this->assertInstanceOf(\DateTimeImmutable::class, $this->deadline->bug_selection);
+        $this->assertInstanceOf(\DateTimeImmutable::class, $this->deadline->feature_selection);
+        $this->assertInstanceOf(\DateTimeImmutable::class, $this->deadline->patch_submission);
+        $this->assertInstanceOf(\DateTimeImmutable::class, $this->deadline->final_report);
+    }
+
+    /**
+     * Test proj_proposal active status when deadline is in future
+     */
+    public function testProjProposalIsActiveFuture()
+    {
+        $future = new \DateTimeImmutable('+1 day');
+        $this->deadline->proj_proposal = $future;
+        
+        $this->assertTrue($this->deadline->isProjProposalActive());
+    }
+
+    /**
+     * Test proj_proposal inactive when deadline is in past
+     */
+    public function testProjProposalIsInactivePast()
+    {
+        $past = new \DateTimeImmutable('-1 day');
+        $this->deadline->proj_proposal = $past;
+        
+        $this->assertFalse($this->deadline->isProjProposalActive());
+    }
+
+    /**
+     * Test bug_selection active status when deadline is in future
+     */
+    public function testBugSelectionIsActiveFuture()
+    {
+        $future = new \DateTimeImmutable('+1 day');
+        $this->deadline->bug_selection = $future;
+        
+        $this->assertTrue($this->deadline->isBugSelectionActive());
+    }
+
+    /**
+     * Test bug_selection inactive when deadline is in past
+     */
+    public function testBugSelectionIsInactivePast()
+    {
+        $past = new \DateTimeImmutable('-1 day');
+        $this->deadline->bug_selection = $past;
+        
+        $this->assertFalse($this->deadline->isBugSelectionActive());
+    }
+
+    /**
+     * Test feature_selection active status when deadline is in future
+     */
+    public function testFeatureSelectionIsActiveFuture()
+    {
+        $future = new \DateTimeImmutable('+1 day');
+        $this->deadline->feature_selection = $future;
+        
+        $this->assertTrue($this->deadline->isFeatureSelectionActive());
+    }
+
+    /**
+     * Test feature_selection inactive when deadline is in past
+     */
+    public function testFeatureSelectionIsInactivePast()
+    {
+        $past = new \DateTimeImmutable('-1 day');
+        $this->deadline->feature_selection = $past;
+        
+        $this->assertFalse($this->deadline->isFeatureSelectionActive());
+    }
+
+    /**
+     * Test patch_submission active status when deadline is in future
+     */
+    public function testPatchSubmissionIsActiveFuture()
+    {
+        $future = new \DateTimeImmutable('+1 day');
+        $this->deadline->patch_submission = $future;
+        
+        $this->assertTrue($this->deadline->isPatchSubmissionActive());
+    }
+
+    /**
+     * Test patch_submission inactive when deadline is in past
+     */
+    public function testPatchSubmissionIsInactivePast()
+    {
+        $past = new \DateTimeImmutable('-1 day');
+        $this->deadline->patch_submission = $past;
+        
+        $this->assertFalse($this->deadline->isPatchSubmissionActive());
+    }
+
+    /**
+     * Test final_report active status when deadline is in future
+     */
+    public function testFinalReportIsActiveFuture()
+    {
+        $future = new \DateTimeImmutable('+1 day');
+        $this->deadline->final_report = $future;
+        
+        $this->assertTrue($this->deadline->isFinalReportActive());
+    }
+
+    /**
+     * Test final_report inactive when deadline is in past
+     */
+    public function testFinalReportIsInactivePast()
+    {
+        $past = new \DateTimeImmutable('-1 day');
+        $this->deadline->final_report = $past;
+        
+        $this->assertFalse($this->deadline->isFinalReportActive());
+    }
+
+    /**
+     * Test deadline year can be set and retrieved
+     */
+    public function testDeadlineYearCanBeSetAndRetrieved()
+    {
+        $deadline2025 = new \Deadline(2025);
+        $this->assertEquals(2025, $deadline2025->year);
+        
+        $deadline2026 = new \Deadline(2026);
+        $this->assertEquals(2026, $deadline2026->year);
+    }
+
+    /**
+     * Test multiple deadlines can exist independently
+     */
+    public function testMultipleDeadlinesAreIndependent()
+    {
+        $deadline2024 = new \Deadline(2024);
+        $deadline2025 = new \Deadline(2025);
+        
+        $deadline2024->proj_proposal = new \DateTimeImmutable('+1 day');
+        $deadline2025->proj_proposal = new \DateTimeImmutable('-1 day');
+        
+        $this->assertTrue($deadline2024->isProjProposalActive());
+        $this->assertFalse($deadline2025->isProjProposalActive());
+    }
+}

--- a/tests/Unit/DiscoverProjectsTest.php
+++ b/tests/Unit/DiscoverProjectsTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\Unit\Base\UnitTestCase;
+use Tests\Mocks\MockGitHubClient;
+class DiscoverProjectsTest extends UnitTestCase
+{
+    public function testSearchByKeywordDelegatesToGitHubDiscovery()
+    {
+        $this->replaceCachedGitHubClient(new MockGitHubClient(
+            searchResults: ['items' => [[
+                'full_name' => 'owner/repo',
+                'description' => 'Mock repository',
+                'html_url' => 'https://github.com/owner/repo',
+                'stargazers_count' => 200,
+                'open_issues' => 10,
+                'language' => 'PHP',
+                'topics' => ['api'],
+                'pushed_at' => '2026-04-26T10:00:00+00:00',
+            ]]],
+            languagesByRepository: ['owner/repo' => ['PHP' => 4_800_000]],
+            participationByRepository: ['owner/repo' => [
+                'all' => array_merge(array_fill(0, 48, 0), [10, 10, 10, 10]),
+                'owner' => array_fill(0, 52, 0),
+            ]]
+        ));
+
+        $result = \DiscoverProjects::searchByKeyword('api', 'PHP', false);
+
+        $this->assertCount(1, $result);
+        $this->assertEquals('github:owner/repo', $result[0]['name']);
+    }
+}

--- a/tests/Unit/FinalGradeTest.php
+++ b/tests/Unit/FinalGradeTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\Unit\Base\UnitTestCase;
+
+
+
+/**
+ * Test suite for FinalGrade entity
+ * 
+ * Tests final grade configuration with year and formula
+ */
+class FinalGradeTest extends UnitTestCase
+{
+    /**
+     * Test final grade can be instantiated
+     */
+    public function testFinalGradeCanBeCreated()
+    {
+        $finalGrade = new \FinalGrade();
+        $this->assertInstanceOf(\FinalGrade::class, $finalGrade);
+    }
+
+    /**
+     * Test final grade year can be set and retrieved
+     */
+    public function testFinalGradeYearCanBeSetAndRetrieved()
+    {
+        $finalGrade = new \FinalGrade();
+        $finalGrade->year = 2024;
+        
+        $this->assertEquals(2024, $finalGrade->year);
+    }
+
+    /**
+     * Test final grade formula can be set and retrieved
+     */
+    public function testFinalGradeFormulaCanBeSetAndRetrieved()
+    {
+        $finalGrade = new \FinalGrade();
+        $formula = '0.3 * milestone_avg + 0.4 * patch_avg + 0.3 * participation';
+        $finalGrade->formula = $formula;
+        
+        $this->assertEquals($formula, $finalGrade->formula);
+    }
+
+    /**
+     * Test final grade supports complex formulas
+     */
+    public function testFinalGradeSupportsComplexFormulas()
+    {
+        $finalGrade = new \FinalGrade();
+        $complexFormula = 'max(0, min(20, sum(grades) / count(grades) + bonus - penalties))';
+        $finalGrade->formula = $complexFormula;
+        
+        $this->assertStringContainsString('max', $finalGrade->formula);
+        $this->assertStringContainsString('min', $finalGrade->formula);
+        $this->assertStringContainsString('sum', $finalGrade->formula);
+    }
+
+    /**
+     * Test multiple final grades for different years
+     */
+    public function testMultipleFinalGradesForDifferentYears()
+    {
+        $finalGrade2024 = new \FinalGrade();
+        $finalGrade2024->year = 2024;
+        $finalGrade2024->formula = '0.5 * test1 + 0.5 * test2';
+        
+        $finalGrade2025 = new \FinalGrade();
+        $finalGrade2025->year = 2025;
+        $finalGrade2025->formula = '0.3 * test1 + 0.3 * test2 + 0.4 * final';
+        
+        $this->assertEquals(2024, $finalGrade2024->year);
+        $this->assertEquals(2025, $finalGrade2025->year);
+        $this->assertNotEquals($finalGrade2024->formula, $finalGrade2025->formula);
+    }
+
+    /**
+     * Test empty formula
+     */
+    public function testFinalGradeWithEmptyFormula()
+    {
+        $finalGrade = new \FinalGrade();
+        $finalGrade->year = 2024;
+        $finalGrade->formula = '';
+        
+        $this->assertEquals('', $finalGrade->formula);
+    }
+
+    /**
+     * Test formula with special characters
+     */
+    public function testFormulaWithSpecialCharacters()
+    {
+        $finalGrade = new \FinalGrade();
+        $formula = 'sum(a * 1.5, b - 0.2, c + 10%) / 3';
+        $finalGrade->formula = $formula;
+        
+        $this->assertEquals($formula, $finalGrade->formula);
+    }
+}

--- a/tests/Unit/GitHub/GitHubDiscoverProjectsTest.php
+++ b/tests/Unit/GitHub/GitHubDiscoverProjectsTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\Unit\Base\UnitTestCase;
+use Tests\Mocks\MockGitHubClient;
+use GitHub\GitHubDiscoverProjects;
+
+/**
+ * Test suite for GitHubDiscoverProjects
+ * 
+ * Tests the GitHub API integration for discovering projects
+ * by keywords and topics.
+ * 
+ * Note: These tests are simplified to work with the current
+ * global client design. For full integration, consider:
+ * 1. Injecting the client as a dependency
+ * 2. Using a test API key or mock response
+ */
+class GitHubDiscoverProjectsTest extends UnitTestCase
+{
+    public function testSearchByTopicsBuildsQueryAndFiltersSmallRepos()
+    {
+        $activity = [
+            'all' => array_merge(array_fill(0, 48, 0), [10, 10, 10, 10]),
+            'owner' => array_fill(0, 52, 0),
+        ];
+        $client = $this->replaceCachedGitHubClient(new MockGitHubClient(
+            searchResults: ['items' => [
+                [
+                    'full_name' => 'big/repo',
+                    'description' => 'Large repository',
+                    'html_url' => 'https://github.com/big/repo',
+                    'stargazers_count' => 12345,
+                    'open_issues' => 456,
+                    'language' => 'PHP',
+                    'topics' => ['testing'],
+                    'pushed_at' => '2026-04-26T10:00:00+00:00',
+                ],
+                [
+                    'full_name' => 'small/repo',
+                    'description' => 'Small repository',
+                    'html_url' => 'https://github.com/small/repo',
+                    'stargazers_count' => 500,
+                    'open_issues' => 10,
+                    'language' => 'PHP',
+                    'topics' => ['testing'],
+                    'pushed_at' => '2026-04-26T10:00:00+00:00',
+                ],
+            ]],
+            languagesByRepository: [
+                'big/repo' => ['PHP' => 4_800_000],
+                'small/repo' => ['PHP' => 40_000],
+            ],
+            participationByRepository: [
+                'big/repo' => $activity,
+                'small/repo' => $activity,
+            ]
+        ));
+
+        $results = GitHubDiscoverProjects::searchByTopics('testing', 'PHP', true);
+
+        $this->assertCount(1, $results);
+        $this->assertEquals('github:big/repo', $results[0]['name']);
+        $this->assertStringContainsString('in:topics', $client->queries[0]);
+        $this->assertStringContainsString('language:PHP', $client->queries[0]);
+        $this->assertStringContainsString('good-first-issues:>30', $client->queries[0]);
+    }
+
+    public function testSearchByKeywordFiltersInactiveRepos()
+    {
+        $this->replaceCachedGitHubClient(new MockGitHubClient(
+            searchResults: ['items' => [
+                [
+                    'full_name' => 'active/repo',
+                    'description' => 'Active repository',
+                    'html_url' => 'https://github.com/active/repo',
+                    'stargazers_count' => 12345,
+                    'open_issues' => 456,
+                    'language' => 'PHP',
+                    'topics' => ['testing'],
+                    'pushed_at' => '2026-04-26T10:00:00+00:00',
+                ],
+                [
+                    'full_name' => 'inactive/repo',
+                    'description' => 'Inactive repository',
+                    'html_url' => 'https://github.com/inactive/repo',
+                    'stargazers_count' => 12345,
+                    'open_issues' => 456,
+                    'language' => 'PHP',
+                    'topics' => ['testing'],
+                    'pushed_at' => '2026-04-26T10:00:00+00:00',
+                ],
+            ]],
+            languagesByRepository: [
+                'active/repo' => ['PHP' => 4_800_000],
+                'inactive/repo' => ['PHP' => 4_800_000],
+            ],
+            participationByRepository: [
+                'active/repo' => [
+                    'all' => array_merge(array_fill(0, 48, 0), [10, 10, 10, 10]),
+                    'owner' => array_fill(0, 52, 0),
+                ],
+                'inactive/repo' => [
+                    'all' => array_merge(array_fill(0, 48, 0), [5, 5, 5, 5]),
+                    'owner' => array_fill(0, 52, 0),
+                ],
+            ]
+        ));
+
+        $results = GitHubDiscoverProjects::searchByKeyword('testing', 'PHP', false);
+
+        $this->assertCount(1, $results);
+        $this->assertEquals('github:active/repo', $results[0]['name']);
+    }
+}

--- a/tests/Unit/GitHub/GitHubPatchTest.php
+++ b/tests/Unit/GitHub/GitHubPatchTest.php
@@ -1,0 +1,410 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\Unit\Base\UnitTestCase;
+
+use GitHub\GitHubPatch;
+
+
+class GitHubPatchTest extends UnitTestCase
+{
+    public function testConstructSupportsCompareUrlWithoutSourceBranch()
+    {
+        $this->mockGitHubClient();
+        $patch = GitHubPatch::construct(
+            'https://github.com/owner/repo/compare/fork:repo:feature',
+            new \Repository('github:owner/repo')
+        );
+
+        $this->assertEquals('fork:repo:feature', $patch->repo_branch);
+        $this->assertEquals('', $patch->src_branch);
+    }
+
+    public function testConstructSupportsTreeUrl()
+    {
+        $this->mockGitHubClient();
+        $patch = GitHubPatch::construct(
+            'https://github.com/fork/repo/tree/feature',
+            new \Repository('github:owner/repo')
+        );
+
+        $this->assertEquals('fork:repo:feature', $patch->repo_branch);
+        $this->assertEquals('', $patch->src_branch);
+    }
+
+    public function testConstructRejectsMismatchedCompareRepository()
+    {
+        $this->expectException(\ValidationException::class);
+        $this->expectExceptionMessage("Patch is not for Project's repository");
+
+        GitHubPatch::construct(
+            'https://github.com/other/repo/compare/main...fork:repo:feature',
+            new \Repository('github:owner/repo')
+        );
+    }
+
+    public function testConstructRejectsMismatchedCompareRepositoryWithoutSourceBranch()
+    {
+        $this->expectException(\ValidationException::class);
+        $this->expectExceptionMessage("Patch is not for Project's repository");
+
+        GitHubPatch::construct(
+            'https://github.com/other/repo/compare/fork:repo:feature',
+            new \Repository('github:owner/repo')
+        );
+    }
+
+    public function testConstructRejectsUnknownUrlFormat()
+    {
+        $this->expectException(\ValidationException::class);
+        $this->expectExceptionMessage('Unknown patch URL format');
+
+        GitHubPatch::construct(
+            'https://github.com/owner/repo/pull/1',
+            new \Repository('github:owner/repo')
+        );
+    }
+
+    public function testConstructRejectsUnparseableCommitUrl()
+    {
+        $this->mockGitHubClient(branchCommitUrl: 'https://example.com/not-github');
+
+        $this->expectException(\ValidationException::class);
+        $this->expectExceptionMessage("Couldn't parse github commit URL");
+
+        GitHubPatch::construct(
+            'https://github.com/owner/repo/tree/feature',
+            new \Repository('github:owner/repo')
+        );
+    }
+
+    public function testConstructRejectsMissingBranch()
+    {
+        $this->mockGitHubClient(branchException: true);
+
+        $this->expectException(\ValidationException::class);
+        $this->expectExceptionMessage('Non-existent patch');
+
+        GitHubPatch::construct(
+            'https://github.com/owner/repo/tree/missing',
+            new \Repository('github:owner/repo')
+        );
+    }
+
+    public function testIsValidHandlesGitHubRuntimeExceptions()
+    {
+        $patch = $this->patchFixture(srcBranch: 'main');
+
+        $this->mockGitHubClient(compareExceptionMessage: 'Not Found');
+        $this->assertFalse($patch->isValid());
+
+        $this->mockGitHubClient(compareExceptionMessage: 'temporary');
+        $this->assertTrue($patch->isValid());
+    }
+
+    public function testSrcBranchFallsBackToRepositoryDefaultBranch()
+    {
+        $this->replaceCachedGitHubClient(new class {
+            public function api($endpoint) {
+                return new class {
+                    public function show($owner, $repo) {
+                        return ['default_branch' => 'develop'];
+                    }
+                };
+            }
+        });
+        $patch = $this->patchFixture();
+
+        $this->assertEquals('develop', $patch->srcBranch());
+    }
+
+    public function testCompareDataIsMappedIntoPatchDetailsAndStats()
+    {
+        $this->mockGitHubClient(
+            compareData: [
+                'commits' => [
+                    [
+                        'sha' => 'firsthash',
+                        'author' => ['login' => 'student'],
+                        'commit' => [
+                            'author' => [
+                                'name' => 'Student User',
+                                'email' => 'ist12345@tecnico.ulisboa.pt',
+                            ],
+                            'message' => "Implement first change.\nCo-authored-by: Pair User <pair@example.com>",
+                        ],
+                    ],
+                    [
+                        'sha' => 'lasthash',
+                        'author' => null,
+                        'commit' => [
+                            'author' => [
+                                'name' => 'Other User',
+                                'email' => 'other@example.com',
+                            ],
+                            'message' => 'Implement second change.',
+                        ],
+                    ],
+                ],
+                'files' => [
+                    ['filename' => 'src/a.php', 'patch' => '+one', 'additions' => 3, 'deletions' => 1],
+                    ['filename' => 'src/b.php', 'additions' => 7, 'deletions' => 2],
+                ],
+            ],
+            patchText: "diff --git a/src/a.php b/src/a.php\n+one\n"
+        );
+
+        $student = new \User('student', 'Student User', 'student@example.com', '', ROLE_STUDENT, false);
+        $student->repository_user = 'github:student';
+
+        $patch = $this->patchFixture(srcBranch: 'main');
+        $patch->group->addStudent($student);
+
+        $this->assertEquals('feature', $patch->branch());
+        $this->assertEquals('fork:repo:feature', $patch->origin());
+        $this->assertSame([
+            [
+                'username' => 'student',
+                'name' => 'Student User',
+                'email' => 'ist12345@tecnico.ulisboa.pt',
+                'message' => "Implement first change.\nCo-authored-by: Pair User <pair@example.com>",
+                'hash' => 'firsthash',
+                'co-authored' => [['', 'Pair User', 'pair@example.com']],
+            ],
+            [
+                'username' => '',
+                'name' => 'Other User',
+                'email' => 'other@example.com',
+                'message' => 'Implement second change.',
+                'hash' => 'lasthash',
+                'co-authored' => [],
+            ],
+        ], $patch->commits());
+        $this->assertSame([
+            ['filename' => 'src/a.php', 'patch' => '+one'],
+            ['filename' => 'src/b.php', 'patch' => ''],
+        ], $patch->diff());
+        $this->assertSame("diff --git a/src/a.php b/src/a.php\n+one\n", $patch->patch());
+
+        $patch->updateStats();
+
+        $this->assertEquals('lasthash', $patch->hash);
+        $this->assertEquals(10, $patch->lines_added);
+        $this->assertEquals(3, $patch->lines_deleted);
+        $this->assertEquals(2, $patch->files_modified);
+        $this->assertTrue($patch->students->contains($student));
+    }
+
+    public function testUrlsAndSetPR()
+    {
+        $patch = $this->patchFixture(srcBranch: 'base branch');
+
+        $pr = new class extends \PullRequest {
+            public function getNumber() { return 77; }
+            public function url(): string { return ''; }
+            public function branchURL(): string { return ''; }
+            public function origin(): string { return ''; }
+            public function isClosed(): bool { return false; }
+            public function wasMerged(): bool { return false; }
+            public function mergedBy(): string { return ''; }
+            public function mergeDate(): \DateTimeImmutable { return new \DateTimeImmutable(); }
+            public function linesAdded(): int { return 0; }
+            public function linesDeleted(): int { return 0; }
+            public function filesModified(): int { return 0; }
+            public function failedCIjobs(string $hash): array { return []; }
+            public function __toString() { return ''; }
+        };
+
+        $patch->setPR($pr);
+
+        $this->assertEquals(77, $patch->pr_number);
+        $this->assertEquals(
+            'https://github.com/owner/repo/compare/base+branch...fork%3Arepo%3Afeature',
+            $patch->getPatchURL()
+        );
+        $this->assertEquals(
+            'https://github.com/owner/repo/commit/abc123',
+            $patch->getCommitURL('abc123')
+        );
+        $this->assertInstanceOf(\GitHub\GitHubPullRequest::class, $patch->getPR());
+    }
+
+    public function testFindAndSetPRForFeaturePatch()
+    {
+        $student = new \User('student', 'Student User', 'student@example.com', '', ROLE_STUDENT, false);
+        $student->repository_user = 'github:student';
+
+        $patch = $this->patchFixture();
+        $patch->type = \PatchType::Feature;
+        $patch->hash = 'abc123';
+        $patch->group->addStudent($student);
+
+        $this->mockGitHubClient(pulls: [
+            [
+                'html_url' => 'https://github.com/owner/repo/pull/4',
+                'user' => ['login' => 'student'],
+                'number' => 4,
+            ],
+        ]);
+
+        $this->assertTrue($patch->findAndSetPR());
+        $this->assertEquals(4, $patch->pr_number);
+    }
+
+    public function testFindAndSetPRAddsCommentWhenPRChanges()
+    {
+        $student = new \User('student', 'Student User', 'student@example.com', '', ROLE_STUDENT, false);
+        $student->repository_user = 'github:student';
+
+        $patch = $this->patchFixture();
+        $patch->type = \PatchType::Feature;
+        $patch->hash = 'abc123';
+        $patch->pr_number = 4;
+        $patch->group->addStudent($student);
+
+        $this->mockGitHubClient(pulls: [
+            [
+                'html_url' => 'https://github.com/owner/repo/pull/9',
+                'user' => ['login' => 'student'],
+                'number' => 9,
+            ],
+        ]);
+
+        $this->assertTrue($patch->findAndSetPR());
+        $this->assertEquals(9, $patch->pr_number);
+        $this->assertCount(1, $patch->comments);
+        $this->assertEquals(
+            "PR updated: 4 \u{2192} 9",
+            $patch->comments->first()->text
+        );
+    }
+
+    public function testFindAndSetPRForBugFixPatchAndRuntimeException()
+    {
+        $submitter = new \User('student', 'Student User', 'student@example.com', '', ROLE_STUDENT, false);
+        $submitter->repository_user = 'github:student';
+
+        $patch = $this->patchFixture();
+        $patch->type = \PatchType::BugFix;
+        $patch->hash = 'abc123';
+        $patch->comments->add(new \PatchComment($patch, 'Submitted', $submitter));
+
+        $this->mockGitHubClient(pulls: [
+            [
+                'html_url' => 'https://github.com/owner/repo/pull/5',
+                'user' => ['login' => 'student'],
+                'number' => 5,
+            ],
+        ]);
+
+        $this->assertTrue($patch->findAndSetPR());
+        $this->assertEquals(5, $patch->pr_number);
+
+        $this->mockGitHubClient(pullsException: true);
+        $this->assertFalse($patch->findAndSetPR());
+    }
+
+    private function patchFixture(string $srcBranch = ''): GitHubPatch
+    {
+        $shift = new \Shift('T01', 2026);
+        $group = new \ProjGroup(1, 2026, $shift);
+        $group->repository = 'github:owner/repo';
+
+        $patch = new GitHubPatch();
+        $patch->group = $group;
+        $patch->repo_branch = 'fork:repo:feature';
+        $patch->src_branch = $srcBranch;
+
+        return $patch;
+    }
+
+    private function mockGitHubClient(
+        string $branchCommitUrl = 'https://api.github.com/repos/fork/repo/commits/abc123',
+        bool $branchException = false,
+        ?string $compareExceptionMessage = null,
+        array $pulls = [],
+        bool $pullsException = false,
+        array $compareData = ['commits' => [], 'files' => []],
+        string $patchText = ''
+    ): void {
+        $this->replaceGitHubClient(new class(
+            $branchCommitUrl,
+            $branchException,
+            $compareExceptionMessage,
+            $pulls,
+            $pullsException,
+            $compareData,
+            $patchText
+        ) {
+            public function __construct(
+                private string $branchCommitUrl,
+                private bool $branchException,
+                private ?string $compareExceptionMessage,
+                private array $pulls,
+                private bool $pullsException,
+                private array $compareData,
+                private string $patchText
+            ) {}
+
+            public function api($endpoint) {
+                return match ($endpoint) {
+                    'repository' => new class($this->branchCommitUrl, $this->branchException) {
+                        public function __construct(private string $branchCommitUrl, private bool $branchException) {}
+
+                        public function branches($org, $repo, $branch) {
+                            if ($this->branchException) {
+                                throw new \Github\Exception\RuntimeException('Not Found');
+                            }
+                            return [
+                                'name' => $branch,
+                                'commit' => [
+                                    'url' => $this->branchCommitUrl,
+                                ],
+                            ];
+                        }
+                    },
+                    'repo' => new class($this->compareExceptionMessage, $this->pulls, $this->pullsException, $this->compareData, $this->patchText) {
+                        public function __construct(
+                            private ?string $compareExceptionMessage,
+                            private array $pulls,
+                            private bool $pullsException,
+                            private array $compareData,
+                            private string $patchText
+                        ) {}
+
+                        public function show($owner, $repo) {
+                            return ['default_branch' => 'main'];
+                        }
+
+                        public function commits() {
+                            return new class($this->compareExceptionMessage, $this->pulls, $this->pullsException, $this->compareData, $this->patchText) {
+                                public function __construct(
+                                    private ?string $compareExceptionMessage,
+                                    private array $pulls,
+                                    private bool $pullsException,
+                                    private array $compareData,
+                                    private string $patchText
+                                ) {}
+
+                                public function compare($org, $repo, $srcBranch, $repoBranch, $accept = null) {
+                                    if ($this->compareExceptionMessage !== null) {
+                                        throw new \Github\Exception\RuntimeException($this->compareExceptionMessage);
+                                    }
+                                    return $accept === null ? $this->compareData : $this->patchText;
+                                }
+
+                                public function pulls($org, $repo, $hash) {
+                                    if ($this->pullsException) {
+                                        throw new \Github\Exception\RuntimeException('temporary');
+                                    }
+                                    return $this->pulls;
+                                }
+                            };
+                        }
+                    },
+                };
+            }
+        });
+    }
+}

--- a/tests/Unit/GitHub/GitHubPullRequestTest.php
+++ b/tests/Unit/GitHub/GitHubPullRequestTest.php
@@ -1,0 +1,230 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\Unit\Base\UnitTestCase;
+
+use GitHub\GitHubPullRequest;
+
+
+class GitHubPullRequestTest extends UnitTestCase
+{
+    public function testPullRequestMetadataComesFromGitHub()
+    {
+        $this->mockGitHubClient();
+        $pr = new GitHubPullRequest(new \Repository('github:owner/repo'), 123);
+
+        $this->assertEquals(123, $pr->getNumber());
+        $this->assertEquals('https://github.com/owner/repo/pull/123', $pr->url());
+        $this->assertEquals('https://github.com/fork/repo/tree/feature-branch', $pr->branchURL());
+        $this->assertEquals('fork:repo:feature-branch', $pr->origin());
+        $this->assertTrue($pr->isClosed());
+        $this->assertEquals('merge-user', $pr->mergedBy());
+        $this->assertEquals('2026-04-26T10:00:00+00:00', $pr->mergeDate()->format('c'));
+        $this->assertEquals(12, $pr->linesAdded());
+        $this->assertEquals(3, $pr->linesDeleted());
+        $this->assertEquals(2, $pr->filesModified());
+        $this->assertEquals('GitHub PR owner/repo#123', (string)$pr);
+    }
+
+    public function testWasMergedReturnsTrueWhenGithubMarksMerged()
+    {
+        $this->mockGitHubClient(merged: true);
+        $pr = new GitHubPullRequest(new \Repository('github:owner/repo'), 123);
+
+        $this->assertTrue($pr->wasMerged());
+    }
+
+    public function testWasMergedDetectsBotMergeCommentWithLabel()
+    {
+        $this->mockGitHubClient(
+            merged: false,
+            state: 'closed',
+            comments: [[
+                'user' => ['login' => 'pytorchmergebot'],
+                'body' => "### Merge started\nThis pull request was merged by automation.",
+            ]],
+            labels: [['name' => 'Merged']]
+        );
+        $pr = new GitHubPullRequest(new \Repository('github:owner/repo'), 123);
+
+        $this->assertTrue($pr->wasMerged());
+    }
+
+    public function testWasMergedReturnsFalseForClosedUnmergedPullRequest()
+    {
+        $this->mockGitHubClient(
+            merged: false,
+            state: 'closed',
+            comments: [[
+                'user' => ['login' => 'someone'],
+                'body' => 'Regular comment.',
+            ]],
+            labels: []
+        );
+        $pr = new GitHubPullRequest(new \Repository('github:owner/repo'), 123);
+
+        $this->assertFalse($pr->wasMerged());
+        $this->assertFalse($pr->has_label('Merged'));
+    }
+
+    public function testCommentsAndLabelsAreLoadedFromIssueApi()
+    {
+        $comments = [['user' => ['login' => 'alice'], 'body' => 'Looks good.']];
+        $labels = [['name' => 'Approved'], ['name' => 'Merged']];
+        $this->mockGitHubClient(comments: $comments, labels: $labels);
+        $pr = new GitHubPullRequest(new \Repository('github:owner/repo'), 123);
+
+        $this->assertEquals($comments, $pr->comments());
+        $this->assertEquals($labels, $pr->labels());
+        $this->assertTrue($pr->has_label('Approved'));
+    }
+
+    public function testFailedCIJobsReturnsStatusesAndWorkflowFailures()
+    {
+        $this->mockGitHubClient();
+        $pr = new GitHubPullRequest(new \Repository('github:owner/repo'), 123);
+
+        $failed = $pr->failedCIjobs('abc123');
+
+        $this->assertCount(2, $failed);
+        $this->assertEquals('lint', $failed[0]['name']);
+        $this->assertEquals('https://ci.example.com/lint', $failed[0]['url']);
+        $this->assertEquals('unit-tests', $failed[1]['name']);
+        $this->assertEquals('https://github.com/owner/repo/actions/jobs/1', $failed[1]['url']);
+    }
+
+    public function testFailedCIJobsIgnoresGitHubRuntimeErrors()
+    {
+        $this->mockGitHubClient(throwOnCi: true);
+        $pr = new GitHubPullRequest(new \Repository('github:owner/repo'), 123);
+
+        $this->assertEquals([], $pr->failedCIjobs('abc123'));
+    }
+
+    private function mockGitHubClient(
+        bool $merged = false,
+        string $state = 'closed',
+        array $comments = [],
+        array $labels = [],
+        bool $throwOnCi = false
+    ): void {
+        $this->replaceGitHubClient(new class($merged, $state, $comments, $labels, $throwOnCi) {
+            public function __construct(
+                private bool $merged,
+                private string $state,
+                private array $comments,
+                private array $labels,
+                private bool $throwOnCi
+            ) {}
+
+            public function api($endpoint) {
+                return match ($endpoint) {
+                    'pr' => new class($this->merged, $this->state) {
+                        public function __construct(private bool $merged, private string $state) {}
+
+                        public function show($org, $repo, $number) {
+                            return [
+                                'state' => $this->state,
+                                'merged' => $this->merged,
+                                'merged_by' => ['login' => 'merge-user'],
+                                'merged_at' => '2026-04-26T10:00:00+00:00',
+                                'additions' => 12,
+                                'deletions' => 3,
+                                'changed_files' => 2,
+                                'head' => [
+                                    'repo' => ['full_name' => 'fork/repo'],
+                                    'ref' => 'feature-branch',
+                                ],
+                            ];
+                        }
+                    },
+                    'issue' => new class($this->comments, $this->labels) {
+                        public function __construct(private array $comments, private array $labels) {}
+
+                        public function comments() {
+                            return new class($this->comments) {
+                                public function __construct(private array $comments) {}
+                                public function all($org, $repo, $number) { return $this->comments; }
+                            };
+                        }
+
+                        public function labels() {
+                            return new class($this->labels) {
+                                public function __construct(private array $labels) {}
+                                public function all($org, $repo, $number) { return $this->labels; }
+                            };
+                        }
+                    },
+                    'repo' => new class($this->throwOnCi) {
+                        public function __construct(private bool $throwOnCi) {}
+
+                        public function statuses() {
+                            return new class($this->throwOnCi) {
+                                public function __construct(private bool $throwOnCi) {}
+
+                                public function combined($org, $repo, $hash) {
+                                    if ($this->throwOnCi) {
+                                        throw new \Github\Exception\RuntimeException('temporary');
+                                    }
+                                    return [
+                                        'statuses' => [
+                                            [
+                                                'state' => 'failure',
+                                                'context' => 'lint',
+                                                'target_url' => 'https://ci.example.com/lint',
+                                                'updated_at' => '2026-04-26T10:00:00+00:00',
+                                            ],
+                                            [
+                                                'state' => 'success',
+                                                'context' => 'style',
+                                                'target_url' => 'https://ci.example.com/style',
+                                                'updated_at' => '2026-04-26T10:00:00+00:00',
+                                            ],
+                                        ],
+                                    ];
+                                }
+                            };
+                        }
+
+                        public function workflowRuns() {
+                            return new class {
+                                public function all($org, $repo, $params) {
+                                    return [
+                                        'workflow_runs' => [
+                                            ['id' => 10, 'conclusion' => 'failure'],
+                                            ['id' => 11, 'conclusion' => 'success'],
+                                        ],
+                                    ];
+                                }
+                            };
+                        }
+
+                        public function workflowJobs() {
+                            return new class {
+                                public function all($org, $repo, $runId) {
+                                    return [
+                                        'jobs' => [
+                                            [
+                                                'name' => 'unit-tests',
+                                                'html_url' => 'https://github.com/owner/repo/actions/jobs/1',
+                                                'completed_at' => '2026-04-26T10:01:00+00:00',
+                                                'conclusion' => 'failure',
+                                            ],
+                                            [
+                                                'name' => 'build',
+                                                'html_url' => 'https://github.com/owner/repo/actions/jobs/2',
+                                                'completed_at' => '2026-04-26T10:02:00+00:00',
+                                                'conclusion' => 'success',
+                                            ],
+                                        ],
+                                    ];
+                                }
+                            };
+                        }
+                    },
+                };
+            }
+        });
+    }
+}

--- a/tests/Unit/GitHub/GitHubUserTest.php
+++ b/tests/Unit/GitHub/GitHubUserTest.php
@@ -1,0 +1,306 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\Unit\Base\UnitTestCase;
+
+use GitHub\GitHubUser;
+
+
+require_once dirname(__DIR__, 3) . '/entities/RepositoryUser.php';
+
+class GitHubUserTest extends UnitTestCase
+{
+    public function testProcessEventsCreatesPullRequestEvents()
+    {
+        $user = new \User('student', 'Student User', 'student@example.com', '', ROLE_STUDENT, false);
+        $events = [];
+
+        $keepGoing = GitHubUser::processEvents($events, $user, [[
+            'id' => '100',
+            'created_at' => '2026-04-26T10:00:00+00:00',
+            'type' => 'PullRequestEvent',
+            'repo' => ['name' => 'owner/repo'],
+            'payload' => [
+                'action' => 'opened',
+                'number' => 123,
+            ],
+        ]]);
+
+        $this->assertTrue($keepGoing);
+        $this->assertCount(1, $events);
+        $this->assertInstanceOf(\PROpenedEvent::class, $events[0]);
+        $this->assertEquals('GitHub PR owner/repo#123', (string)$events[0]->pr);
+    }
+
+    public function testProcessEventsCreatesReopenedPullRequestEvents()
+    {
+        $user = new \User('student', 'Student User', 'student@example.com', '', ROLE_STUDENT, false);
+        $events = [];
+
+        GitHubUser::processEvents($events, $user, [[
+            'id' => '101',
+            'created_at' => '2026-04-26T10:00:00+00:00',
+            'type' => 'PullRequestEvent',
+            'repo' => ['name' => 'owner/repo'],
+            'payload' => [
+                'action' => 'reopened',
+                'number' => 124,
+            ],
+        ]]);
+
+        $this->assertCount(1, $events);
+        $this->assertEquals('GitHub PR owner/repo#124', (string)$events[0]->pr);
+    }
+
+    public function testProcessEventsIgnoresNonOpeningEvents()
+    {
+        $user = new \User('student', 'Student User', 'student@example.com', '', ROLE_STUDENT, false);
+        $events = [];
+
+        $keepGoing = GitHubUser::processEvents($events, $user, [
+            [
+                'id' => '102',
+                'created_at' => '2026-04-26T10:00:00+00:00',
+                'type' => 'PullRequestEvent',
+                'repo' => ['name' => 'owner/repo'],
+                'payload' => [
+                    'action' => 'closed',
+                    'number' => 125,
+                ],
+            ],
+            [
+                'id' => '103',
+                'created_at' => '2026-04-26T10:00:00+00:00',
+                'type' => 'IssuesEvent',
+                'repo' => ['name' => 'owner/repo'],
+                'payload' => [
+                    'action' => 'opened',
+                ],
+            ],
+        ]);
+
+        $this->assertTrue($keepGoing);
+        $this->assertSame([], $events);
+    }
+
+    public function testProcessEventsDoesNotFilterByProcessedIdWhileGithubEventsAreIncomplete()
+    {
+        $user = new \User('student', 'Student User', 'student@example.com', '', ROLE_STUDENT, false);
+        $user->repository_last_processed_id = '200';
+        $events = [];
+
+        $keepGoing = GitHubUser::processEvents($events, $user, [[
+            'id' => '199',
+            'created_at' => '2026-04-26T10:00:00+00:00',
+            'type' => 'PullRequestEvent',
+            'repo' => ['name' => 'owner/repo'],
+            'payload' => [
+                'action' => 'opened',
+                'number' => 123,
+            ],
+        ]]);
+
+        $this->assertTrue($keepGoing);
+        $this->assertCount(1, $events);
+        $this->assertEquals('GitHub PR owner/repo#123', (string)$events[0]->pr);
+    }
+
+    public function testStatsReturnsEmptyArrayWhenGithubErrors()
+    {
+        $this->replaceGitHubClient(new class {
+            public function api($endpoint) {
+                return new class {
+                    public function show($username) {
+                        throw new \Github\Exception\RuntimeException('temporary');
+                    }
+                };
+            }
+        });
+        $user = new \User('student', 'Student User', 'student@example.com', '', ROLE_STUDENT, false);
+        $user->repository_user = 'github:student';
+
+        $this->assertNull(GitHubUser::name(new \RepositoryUser($user)));
+    }
+
+    public function testIsValidReturnsFalseForNotFound()
+    {
+        $this->replaceGitHubClient(new class {
+            public function api($endpoint) {
+                return new class {
+                    public function show($username) {
+                        throw new \Github\Exception\RuntimeException('Not Found');
+                    }
+                };
+            }
+        });
+        $user = new \User('student', 'Student User', 'student@example.com', '', ROLE_STUDENT, false);
+        $user->repository_user = 'github:student';
+
+        $this->assertFalse(GitHubUser::isValid(new \RepositoryUser($user)));
+    }
+
+    public function testGetUnprocessedEventsFetchesPagesAndUpdatesUserState()
+    {
+        $this->ensureGitHubEtagHelpers();
+        $this->replaceGitHubClient($this->mockPaginatedEventsGitHubClient());
+
+        $user = new \User('student', 'Student User', 'student@example.com', '', ROLE_STUDENT, false);
+        $user->repository_user = 'github:student';
+        $user->repository_last_processed_id = '100';
+        $repoUser = new \RepositoryUser($user);
+
+        $events = GitHubUser::getUnprocessedEvents($repoUser);
+
+        $this->assertCount(2, $events);
+        $this->assertEquals('GitHub PR owner/repo#2', (string)$events[0]->pr);
+        $this->assertEquals('GitHub PR owner/repo#1', (string)$events[1]->pr);
+        $this->assertEquals('"etag-1"', $user->repository_etag);
+        $this->assertEquals(300, $user->repository_last_processed_id);
+    }
+
+    public function testGetUnprocessedEventsKeepsLastProcessedIdWhenNoEvents()
+    {
+        $this->ensureGitHubEtagHelpers();
+        $this->replaceGitHubClient($this->mockPaginatedEventsGitHubClient([]));
+
+        $user = new \User('student', 'Student User', 'student@example.com', '', ROLE_STUDENT, false);
+        $user->repository_user = 'github:student';
+        $user->repository_last_processed_id = '100';
+        $repoUser = new \RepositoryUser($user);
+
+        $events = GitHubUser::getUnprocessedEvents($repoUser);
+
+        $this->assertSame([], $events);
+        $this->assertEquals('"etag-1"', $user->repository_etag);
+        $this->assertEquals('100', $user->repository_last_processed_id);
+    }
+
+    private function ensureGitHubEtagHelpers(): void
+    {
+        if (!function_exists('\\GitHub\\github_remove_etag')) {
+            eval('namespace GitHub; function github_set_etag($etag) {} function github_remove_etag() {}');
+        }
+    }
+
+    private function mockPaginatedEventsGitHubClient(?array $firstPage = null): \Github\Client
+    {
+        $firstPage ??= [
+            [
+                'id' => '300',
+                'created_at' => '2026-04-26T11:00:00+00:00',
+                'type' => 'PullRequestEvent',
+                'repo' => ['name' => 'owner/repo'],
+                'payload' => [
+                    'action' => 'opened',
+                    'number' => 1,
+                ],
+            ],
+        ];
+
+        $nextPage = [
+            [
+                'id' => '250',
+                'created_at' => '2026-04-26T10:00:00+00:00',
+                'type' => 'PullRequestEvent',
+                'repo' => ['name' => 'owner/repo'],
+                'payload' => [
+                    'action' => 'reopened',
+                    'number' => 2,
+                ],
+            ],
+        ];
+
+        return new class($firstPage, $nextPage) extends \Github\Client {
+            private \Psr\Http\Message\ResponseInterface $lastResponse;
+
+            public function __construct(private array $firstPage, private array $nextPage)
+            {
+                parent::__construct();
+                $this->lastResponse = $this->jsonResponse([], ['etag' => '"etag-0"']);
+            }
+
+            public function user($type): \Github\Api\AbstractApi
+            {
+                return new class($this) extends \Github\Api\AbstractApi {
+                    public function __construct(private object $client)
+                    {
+                        parent::__construct($client);
+                    }
+
+                    public function events($username): array
+                    {
+                        $headers = ['etag' => '"etag-1"'];
+                        if ($this->client->hasNextPage()) {
+                            $headers['Link'] = '<https://api.github.test/events?page=2>; rel="next"';
+                        }
+                        $this->client->setLastResponse($this->client->jsonResponse($this->client->firstPage(), $headers));
+
+                        return $this->client->firstPage();
+                    }
+                };
+            }
+
+            public function getLastResponse(): ?\Psr\Http\Message\ResponseInterface
+            {
+                return $this->lastResponse;
+            }
+
+            public function getHttpClient(): \Http\Client\Common\HttpMethodsClientInterface
+            {
+                return new class($this) implements \Http\Client\Common\HttpMethodsClientInterface {
+                    public function __construct(private object $client) {}
+
+                    public function get($uri, array $headers = []): \Psr\Http\Message\ResponseInterface
+                    {
+                        $response = $this->client->jsonResponse($this->client->nextPage(), ['etag' => '"etag-2"']);
+                        $this->client->setLastResponse($response);
+                        return $response;
+                    }
+
+                    public function head($uri, array $headers = []): \Psr\Http\Message\ResponseInterface { return $this->get($uri, $headers); }
+                    public function trace($uri, array $headers = []): \Psr\Http\Message\ResponseInterface { return $this->get($uri, $headers); }
+                    public function post($uri, array $headers = [], $body = null): \Psr\Http\Message\ResponseInterface { return $this->get($uri, $headers); }
+                    public function put($uri, array $headers = [], $body = null): \Psr\Http\Message\ResponseInterface { return $this->get($uri, $headers); }
+                    public function patch($uri, array $headers = [], $body = null): \Psr\Http\Message\ResponseInterface { return $this->get($uri, $headers); }
+                    public function delete($uri, array $headers = [], $body = null): \Psr\Http\Message\ResponseInterface { return $this->get($uri, $headers); }
+                    public function options($uri, array $headers = [], $body = null): \Psr\Http\Message\ResponseInterface { return $this->get($uri, $headers); }
+                    public function send(string $method, $uri, array $headers = [], $body = null): \Psr\Http\Message\ResponseInterface { return $this->get($uri, $headers); }
+                    public function sendRequest(\Psr\Http\Message\RequestInterface $request): \Psr\Http\Message\ResponseInterface
+                    {
+                        return $this->get((string)$request->getUri());
+                    }
+                };
+            }
+
+            public function firstPage(): array
+            {
+                return $this->firstPage;
+            }
+
+            public function nextPage(): array
+            {
+                return $this->nextPage;
+            }
+
+            public function hasNextPage(): bool
+            {
+                return $this->firstPage !== [];
+            }
+
+            public function setLastResponse(\Psr\Http\Message\ResponseInterface $response): void
+            {
+                $this->lastResponse = $response;
+            }
+
+            public function jsonResponse(array $data, array $headers): \Psr\Http\Message\ResponseInterface
+            {
+                return new \Nyholm\Psr7\Response(
+                    200,
+                    ['Content-Type' => 'application/json'] + $headers,
+                    json_encode($data)
+                );
+            }
+        };
+    }
+}

--- a/tests/Unit/GradeTest.php
+++ b/tests/Unit/GradeTest.php
@@ -1,0 +1,357 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\Unit\Base\UnitTestCase;
+
+
+use ValidationException;
+
+/**
+ * Test suite for Grade entity
+ * 
+ * Tests grade creation, field validation, and late days tracking
+ */
+class GradeTest extends UnitTestCase
+{
+    private \User $testUser;
+    private \Milestone $testMilestone;
+    private \Grade $grade;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Create a test user for session
+        $this->testUser = new \User(
+            username: 'testuser',
+            name: 'Test User',
+            email: 'test@example.com',
+            photo: '',
+            role: ROLE_STUDENT,
+            dummy: false
+        );
+
+        // Create test milestone with required constructor parameters
+        $this->testMilestone = new \Milestone(2024, 'Sprint 1');
+        $this->testMilestone->description = 'First sprint';
+        $this->testMilestone->individual = false;
+        $this->testMilestone->field1 = 'Functionality';
+        $this->testMilestone->range1 = 100;
+        $this->testMilestone->field2 = 'Code Quality';
+        $this->testMilestone->range2 = 100;
+        $this->testMilestone->field3 = '';
+        $this->testMilestone->field4 = '';
+
+        // Create test grade
+        $this->grade = new \Grade();
+        $this->grade->user = $this->testUser;
+        $this->grade->milestone = $this->testMilestone;
+        $this->grade->field1 = 85;
+        $this->grade->field2 = 90;
+        $this->grade->field3 = null;
+        $this->grade->field4 = null;
+        $this->grade->late_days = 0;
+    }
+
+    /**
+     * Test that grade can be created with user and milestone
+     */
+    public function testGradeCanBeCreated()
+    {
+        $this->assertInstanceOf(\Grade::class, $this->grade);
+        $this->assertEquals($this->testUser, $this->grade->user);
+        $this->assertEquals($this->testMilestone, $this->grade->milestone);
+    }
+
+    /**
+     * Test that grade fields can be set
+     */
+    public function testGradeFieldsCanBeSet()
+    {
+        $this->assertEquals(85, $this->grade->field1);
+        $this->assertEquals(90, $this->grade->field2);
+    }
+
+    /**
+     * Test that late_days defaults to zero
+     */
+    public function testLateDaysDefaultsToZero()
+    {
+        $grade = new \Grade();
+        $grade->user = $this->testUser;
+        $grade->milestone = $this->testMilestone;
+        
+        $this->assertEquals(0, $grade->late_days);
+    }
+
+    /**
+     * Test that grade fields can be null
+     */
+    public function testGradeFieldsCanBeNull()
+    {
+        $this->grade->field3 = null;
+        $this->grade->field4 = null;
+        
+        $this->assertNull($this->grade->field3);
+        $this->assertNull($this->grade->field4);
+    }
+
+    /**
+     * Test that late_days can be set
+     */
+    public function testLateDaysCanBeSet()
+    {
+        $this->grade->late_days = 5;
+        $this->assertEquals(5, $this->grade->late_days);
+    }
+
+    /**
+     * Test that grade fields accept various valid values
+     */
+    public function testGradeFieldsAcceptValidValues()
+    {
+        $this->grade->field1 = 0;
+        $this->assertEquals(0, $this->grade->field1);
+        
+        $this->grade->field1 = 50;
+        $this->assertEquals(50, $this->grade->field1);
+        
+        $this->grade->field1 = 100;
+        $this->assertEquals(100, $this->grade->field1);
+    }
+
+    /**
+     * Test validation passes for valid field values within range
+     */
+    public function testValidateFieldsPassesForValidValues()
+    {
+        $this->grade->field1 = 50;
+        $this->grade->field2 = 75;
+        $this->grade->late_days = 2;
+
+        $this->grade->validateFields();
+
+        $this->assertEquals(50, $this->grade->field1);
+        $this->assertEquals(75, $this->grade->field2);
+        $this->assertEquals(2, $this->grade->late_days);
+    }
+
+    /**
+     * Test validation passes when fields are null for empty milestone fields
+     */
+    public function testValidateFieldsPassesForNullFields()
+    {
+        $this->grade->field3 = null;
+        $this->grade->field4 = null;
+
+        $this->grade->validateFields();
+
+        $this->assertNull($this->grade->field3);
+        $this->assertNull($this->grade->field4);
+    }
+
+    /**
+     * Test validation fails for field value exceeding range
+     */
+    public function testValidateFieldsFailsForExceededRange()
+    {
+        $this->grade->field1 = 150; // Exceeds range of 100
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage("exceeds allowed range");
+
+        $this->grade->validateFields();
+    }
+
+    /**
+     * Test validation fails for negative field values
+     */
+    public function testValidateFieldsFailsForNegativeValues()
+    {
+        $this->grade->field1 = -5;
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage("exceeds allowed range");
+
+        $this->grade->validateFields();
+    }
+
+    /**
+     * Test validation fails for negative late_days
+     */
+    public function testValidateFieldsFailsForNegativeLateDays()
+    {
+        $this->grade->late_days = -1;
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage("Late days cannot be negative");
+
+        $this->grade->validateFields();
+    }
+
+    /**
+     * Test all field ranges are validated
+     */
+    public function testValidateFieldsChecksAllRanges()
+    {
+        $this->testMilestone->field3 = 'Design';
+        $this->testMilestone->range3 = 50;
+        $this->grade->field3 = 75; // Exceeds range of 50
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage("Field 3 exceeds allowed range");
+
+        $this->grade->validateFields();
+    }
+
+    /**
+     * Test zero late days is valid
+     */
+    public function testValidateFieldsAllowsZeroLateDays()
+    {
+        $this->grade->late_days = 0;
+
+        $this->grade->validateFields();
+
+        $this->assertEquals(0, $this->grade->late_days);
+    }
+
+    /**
+     * Test boundary values for field ranges
+     */
+    public function testValidateFieldsBoundaryValues()
+    {
+        // Test minimum boundary
+        $this->grade->field1 = 0;
+
+        $this->grade->validateFields();
+        $this->assertEquals(0, $this->grade->field1);
+        
+        // Test maximum boundary
+        $this->grade->field1 = 100;
+
+        $this->grade->validateFields();
+        $this->assertEquals(100, $this->grade->field1);
+    }
+
+    /**
+     * Test that grade can be created for different users
+     */
+    public function testGradeCanBeCreatedForDifferentUsers()
+    {
+        $user1 = new \User('user1', 'User 1', 'user1@example.com', '', ROLE_STUDENT, false);
+        $user2 = new \User('user2', 'User 2', 'user2@example.com', '', ROLE_STUDENT, false);
+
+        $grade1 = new \Grade();
+        $grade1->user = $user1;
+        $grade1->milestone = $this->testMilestone;
+        $grade1->field1 = 80;
+
+        $grade2 = new \Grade();
+        $grade2->user = $user2;
+        $grade2->milestone = $this->testMilestone;
+        $grade2->field1 = 90;
+
+        $this->assertEquals('user1', $grade1->user->id);
+        $this->assertEquals('user2', $grade2->user->id);
+        $this->assertEquals(80, $grade1->field1);
+        $this->assertEquals(90, $grade2->field1);
+    }
+
+    /**
+     * Test that grade references are preserved
+     */
+    public function testGradeReferencesArePreserved()
+    {
+        $this->assertSame($this->testUser, $this->grade->user);
+        $this->assertSame($this->testMilestone, $this->grade->milestone);
+    }
+
+    /**
+     * Test that late_days can track multiple days
+     */
+    public function testLateDaysCanTrackMultipleDays()
+    {
+        for ($days = 0; $days <= 10; $days++) {
+            $grade = new \Grade();
+            $grade->user = $this->testUser;
+            $grade->milestone = $this->testMilestone;
+            $grade->late_days = $days;
+            
+            $this->assertEquals($days, $grade->late_days);
+        }
+    }
+
+    /**
+     * Test that grade instances are independent
+     */
+    public function testGradeInstancesAreIndependent()
+    {
+        $grade1 = new \Grade();
+        $grade1->user = $this->testUser;
+        $grade1->milestone = $this->testMilestone;
+        $grade1->field1 = 80;
+
+        $grade2 = new \Grade();
+        $grade2->user = $this->testUser;
+        $grade2->milestone = $this->testMilestone;
+        $grade2->field1 = 90;
+
+        $this->assertEquals(80, $grade1->field1);
+        $this->assertEquals(90, $grade2->field1);
+    }
+
+    /**
+     * Test grade field types
+     */
+    public function testGradeFieldTypesArePreserved()
+    {
+        $this->assertIsInt($this->grade->field1);
+        $this->assertIsInt($this->grade->field2);
+        $this->assertIsInt($this->grade->late_days);
+    }
+
+    /**
+     * Test that all four field properties exist
+     */
+    public function testAllFourFieldPropertiesExist()
+    {
+        $reflection = new \ReflectionClass(\Grade::class);
+        
+        $this->assertTrue($reflection->hasProperty('field1'));
+        $this->assertTrue($reflection->hasProperty('field2'));
+        $this->assertTrue($reflection->hasProperty('field3'));
+        $this->assertTrue($reflection->hasProperty('field4'));
+    }
+
+    /**
+     * Test grade with empty fields
+     */
+    public function testGradeWithEmptyFields()
+    {
+        $grade = new \Grade();
+        $grade->user = $this->testUser;
+        
+        // Create milestone with empty fields
+        $milestone = new \Milestone(2024, 'Test');
+        $milestone->field1 = '';  // Empty means not graded
+        $milestone->field2 = '';
+        $milestone->field3 = '';
+        $milestone->field4 = '';
+        
+        $grade->milestone = $milestone;
+        
+        // Initialize fields to null
+        $grade->field1 = null;
+        $grade->field2 = null;
+        $grade->field3 = null;
+        $grade->field4 = null;
+        
+        // Fields should be null when milestone fields are empty
+        $this->assertNull($grade->field1);
+        $this->assertNull($grade->field2);
+        $this->assertNull($grade->field3);
+        $this->assertNull($grade->field4);
+    }
+}

--- a/tests/Unit/IssueTest.php
+++ b/tests/Unit/IssueTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\Unit\Base\UnitTestCase;
+
+
+
+/**
+ * Test suite for Issue entity
+ * 
+ * Tests abstract Issue factory pattern for creating issue instances
+ */
+class IssueTest extends UnitTestCase
+{
+    /**
+     * Test Issue factory returns GitHubIssue for valid GitHub URL
+     */
+    public function testIssueFactoryReturnsGitHubIssueForValidUrl()
+    {
+        $validGitHubUrl = 'https://github.com/owner/repo/issues/123';
+        $result = \Issue::factory($validGitHubUrl);
+        
+        $this->assertInstanceOf(\GitHub\GitHubIssue::class, $result);
+    }
+
+    /**
+     * Test Issue factory returns null for invalid URL
+     */
+    public function testIssueFactoryReturnsNullForInvalidUrl()
+    {
+        $result = \Issue::factory('https://example.com/invalid');
+        
+        $this->assertNull($result);
+    }
+
+    /**
+     * Test Issue is abstract and cannot be instantiated directly
+     */
+    public function testIssueIsAbstract()
+    {
+        $reflection = new \ReflectionClass(\Issue::class);
+        $this->assertTrue($reflection->isAbstract());
+    }
+
+    /**
+     * Test Issue has required abstract methods
+     */
+    public function testIssueHasRequiredAbstractMethods()
+    {
+        $reflection = new \ReflectionClass(\Issue::class);
+        $methods = $reflection->getMethods(\ReflectionMethod::IS_ABSTRACT);
+        
+        $methodNames = array_map(fn($m) => $m->getName(), $methods);
+        
+        $this->assertContains('getTitle', $methodNames);
+        $this->assertContains('getDescription', $methodNames);
+    }
+
+    /**
+     * Test Issue factory is static
+     */
+    public function testIssueFactoryIsStatic()
+    {
+        $reflection = new \ReflectionClass(\Issue::class);
+        $method = $reflection->getMethod('factory');
+        
+        $this->assertTrue($method->isStatic());
+    }
+}

--- a/tests/Unit/MilestoneTest.php
+++ b/tests/Unit/MilestoneTest.php
@@ -1,0 +1,249 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\Unit\Base\UnitTestCase;
+
+
+
+/**
+ * Test suite for Milestone entity
+ * 
+ * Tests milestone creation, properties, and structure
+ */
+class MilestoneTest extends UnitTestCase
+{
+    private \Milestone $milestone;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->milestone = new \Milestone(2024, 'Sprint 1');
+        $this->milestone->description = 'First sprint of the project';
+        $this->milestone->page = '/sprints/1';
+        $this->milestone->individual = false;
+        $this->milestone->field1 = 'Functionality';
+        $this->milestone->points1 = 40;
+        $this->milestone->range1 = 100;
+        $this->milestone->field2 = 'Code Quality';
+        $this->milestone->points2 = 30;
+        $this->milestone->range2 = 100;
+        $this->milestone->field3 = 'Documentation';
+        $this->milestone->points3 = 20;
+        $this->milestone->range3 = 100;
+        $this->milestone->field4 = '';
+        $this->milestone->points4 = 0;
+        $this->milestone->range4 = 0;
+    }
+
+    /**
+     * Test that milestone can be created
+     */
+    public function testMilestoneCanBeCreated()
+    {
+        $this->assertInstanceOf(\Milestone::class, $this->milestone);
+    }
+
+    /**
+     * Test that milestone properties can be set and retrieved
+     */
+    public function testMilestonePropertiesCanBeSet()
+    {
+        $this->assertEquals(2024, $this->milestone->year);
+        $this->assertEquals('Sprint 1', $this->milestone->name);
+        $this->assertEquals('First sprint of the project', $this->milestone->description);
+        $this->assertEquals('/sprints/1', $this->milestone->page);
+    }
+
+    /**
+     * Test that milestone individual flag works
+     */
+    public function testMilestoneCanBeIndividualOrGroup()
+    {
+        $this->assertFalse($this->milestone->individual);
+        
+        $this->milestone->individual = true;
+        $this->assertTrue($this->milestone->individual);
+    }
+
+    /**
+     * Test that milestone fields can be configured
+     */
+    public function testMilestoneFieldsCanBeConfigured()
+    {
+        $this->assertEquals('Functionality', $this->milestone->field1);
+        $this->assertEquals('Code Quality', $this->milestone->field2);
+        $this->assertEquals('Documentation', $this->milestone->field3);
+        $this->assertEquals('', $this->milestone->field4);
+    }
+
+    /**
+     * Test that milestone points can be configured
+     */
+    public function testMilestonePointsCanBeConfigured()
+    {
+        $this->assertEquals(40, $this->milestone->points1);
+        $this->assertEquals(30, $this->milestone->points2);
+        $this->assertEquals(20, $this->milestone->points3);
+        $this->assertEquals(0, $this->milestone->points4);
+    }
+
+    /**
+     * Test that milestone ranges can be configured
+     */
+    public function testMilestoneRangesCanBeConfigured()
+    {
+        $this->assertEquals(100, $this->milestone->range1);
+        $this->assertEquals(100, $this->milestone->range2);
+        $this->assertEquals(100, $this->milestone->range3);
+        $this->assertEquals(0, $this->milestone->range4);
+    }
+
+    /**
+     * Test default values for description
+     */
+    public function testDefaultDescription()
+    {
+        $milestone = new \Milestone(2024, 'Test');
+        $this->assertEquals('', $milestone->description);
+    }
+
+    /**
+     * Test default values for page
+     */
+    public function testDefaultPage()
+    {
+        $milestone = new \Milestone(2024, 'Test');
+        $this->assertEquals('', $milestone->page);
+    }
+
+    /**
+     * Test default values for individual
+     */
+    public function testDefaultIndividual()
+    {
+        $milestone = new \Milestone(2024, 'Test');
+        $this->assertFalse($milestone->individual);
+    }
+
+    /**
+     * Test default values for fields
+     */
+    public function testDefaultFields()
+    {
+        $milestone = new \Milestone(2024, 'Test');
+        $this->assertEquals('', $milestone->field1);
+        $this->assertEquals('', $milestone->field2);
+        $this->assertEquals('', $milestone->field3);
+        $this->assertEquals('', $milestone->field4);
+    }
+
+    /**
+     * Test default values for points
+     */
+    public function testDefaultPoints()
+    {
+        $milestone = new \Milestone(2024, 'Test');
+        $this->assertEquals(0, $milestone->points1);
+        $this->assertEquals(0, $milestone->points2);
+        $this->assertEquals(0, $milestone->points3);
+        $this->assertEquals(0, $milestone->points4);
+    }
+
+    /**
+     * Test default values for ranges
+     */
+    public function testDefaultRanges()
+    {
+        $milestone = new \Milestone(2024, 'Test');
+        $this->assertEquals(0, $milestone->range1);
+        $this->assertEquals(0, $milestone->range2);
+        $this->assertEquals(0, $milestone->range3);
+        $this->assertEquals(0, $milestone->range4);
+    }
+
+    /**
+     * Test that milestone can have different configurations
+     */
+    public function testMilestoneWithDifferentConfigurations()
+    {
+        // 2-field milestone
+        $m1 = new \Milestone(2024, 'M1');
+        $m1->field1 = 'Part A';
+        $m1->field2 = 'Part B';
+
+        // 3-field milestone
+        $m2 = new \Milestone(2024, 'M2');
+        $m2->field1 = 'Part A';
+        $m2->field2 = 'Part B';
+        $m2->field3 = 'Part C';
+
+        $this->assertEquals('', $m1->field3);
+        $this->assertEquals('', $m1->field4);
+        
+        $this->assertEquals('Part C', $m2->field3);
+        $this->assertEquals('', $m2->field4);
+    }
+
+    /**
+     * Test milestone year property
+     */
+    public function testMilestoneYear()
+    {
+        $this->assertEquals(2024, $this->milestone->year);
+        
+        $milestone2024 = new \Milestone(2024, 'Test');
+        $this->assertEquals(2024, $milestone2024->year);
+
+        $milestone2025 = new \Milestone(2025, 'Test');
+        $this->assertEquals(2025, $milestone2025->year);
+    }
+
+    /**
+     * Test milestone name property
+     */
+    public function testMilestoneName()
+    {
+        $this->assertEquals('Sprint 1', $this->milestone->name);
+        
+        $this->milestone->name = 'Sprint 2';
+        $this->assertEquals('Sprint 2', $this->milestone->name);
+    }
+
+    /**
+     * Test that different milestones can exist
+     */
+    public function testDifferentMilestonesAreDifferent()
+    {
+        $m1 = new \Milestone(2024, 'Milestone 1');
+        $m2 = new \Milestone(2024, 'Milestone 2');
+
+        $this->assertNotSame($m1, $m2);
+        $this->assertNotEquals($m1->name, $m2->name);
+    }
+
+    /**
+     * Test milestone structure has all required properties
+     */
+    public function testMilestoneHasAllProperties()
+    {
+        $reflection = new \ReflectionClass(\Milestone::class);
+        
+        $requiredProperties = [
+            'year', 'name', 'description', 'page',
+            'individual',
+            'field1', 'points1', 'range1',
+            'field2', 'points2', 'range2',
+            'field3', 'points3', 'range3',
+            'field4', 'points4', 'range4'
+        ];
+
+        foreach ($requiredProperties as $property) {
+            $this->assertTrue(
+                $reflection->hasProperty($property),
+                "Milestone should have property: $property"
+            );
+        }
+    }
+}

--- a/tests/Unit/PatchCIErrorTest.php
+++ b/tests/Unit/PatchCIErrorTest.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\Unit\Base\UnitTestCase;
+
+
+
+/**
+ * Test suite for PatchCIError entity
+ * 
+ * Tests CI error tracking for patch build failures
+ */
+class PatchCIErrorTest extends UnitTestCase
+{
+    private \Patch $patch;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->patch = $this->createMock(\Patch::class);
+    }
+
+    /**
+     * Test patch CI error can be instantiated with required parameters
+     */
+    public function testPatchCIErrorCanBeInstantiated()
+    {
+        $now = new \DateTimeImmutable();
+        $ciError = new \PatchCIError($this->patch, 'abc123', 'TestError', 'https://ci.example.com/error', $now);
+        $this->assertInstanceOf(\PatchCIError::class, $ciError);
+    }
+
+    /**
+     * Test patch CI error has patch relationship
+     */
+    public function testPatchCIErrorHasPatchRelationship()
+    {
+        $now = new \DateTimeImmutable();
+        $ciError = new \PatchCIError($this->patch, 'abc123', 'TestError', 'https://ci.example.com/error', $now);
+        
+        $this->assertEquals($this->patch, $ciError->patch);
+    }
+
+    /**
+     * Test patch CI error has hash
+     */
+    public function testPatchCIErrorHasHash()
+    {
+        $now = new \DateTimeImmutable();
+        $hash = 'abc123def456';
+        $ciError = new \PatchCIError($this->patch, $hash, 'TestError', 'https://ci.example.com/error', $now);
+        
+        $this->assertEquals($hash, $ciError->hash);
+    }
+
+    /**
+     * Test patch CI error has name
+     */
+    public function testPatchCIErrorHasName()
+    {
+        $now = new \DateTimeImmutable();
+        $name = 'CompilationError';
+        $ciError = new \PatchCIError($this->patch, 'abc123', $name, 'https://ci.example.com/error', $now);
+        
+        $this->assertEquals($name, $ciError->name);
+    }
+
+    /**
+     * Test patch CI error has URL
+     */
+    public function testPatchCIErrorHasUrl()
+    {
+        $now = new \DateTimeImmutable();
+        $url = 'https://ci.example.com/build/12345/error';
+        $ciError = new \PatchCIError($this->patch, 'abc123', 'TestError', $url, $now);
+        
+        $this->assertEquals($url, $ciError->url);
+    }
+
+    /**
+     * Test patch CI error has time
+     */
+    public function testPatchCIErrorHasTime()
+    {
+        $now = new \DateTimeImmutable();
+        $ciError = new \PatchCIError($this->patch, 'abc123', 'TestError', 'https://ci.example.com/error', $now);
+        
+        $this->assertEquals($now, $ciError->time);
+    }
+
+    /**
+     * Test patch CI error can get commit URL from patch
+     */
+    public function testPatchCIErrorCanGetCommitUrl()
+    {
+        $now = new \DateTimeImmutable();
+        $expectedUrl = 'https://github.com/owner/repo/commit/abc123';
+        
+        // Mock the patch to return the expected commit URL
+        $mockPatch = $this->createMock(\Patch::class);
+        $mockPatch->expects($this->once())
+            ->method('getCommitURL')
+            ->with('abc123')
+            ->willReturn($expectedUrl);
+        
+        $ciError = new \PatchCIError($mockPatch, 'abc123', 'TestError', 'https://ci.example.com/error', $now);
+        
+        $this->assertEquals($expectedUrl, $ciError->getCommitURL());
+    }
+
+    /**
+     * Test multiple CI errors can be tracked
+     */
+    public function testMultipleCIErrorsCanBeTracked()
+    {
+        $time1 = new \DateTimeImmutable('-2 hours');
+        $error1 = new \PatchCIError($this->patch, 'abc123', 'Error1', 'https://ci.example.com/1', $time1);
+        
+        $time2 = new \DateTimeImmutable('-1 hour');
+        $error2 = new \PatchCIError($this->patch, 'def456', 'Error2', 'https://ci.example.com/2', $time2);
+        
+        $this->assertEquals('abc123', $error1->hash);
+        $this->assertEquals('def456', $error2->hash);
+        $this->assertNotEquals($error1->time, $error2->time);
+    }
+
+    /**
+     * Test patch CI error timestamp ordering
+     */
+    public function testPatchCIErrorTimestampOrdering()
+    {
+        $error1 = new \PatchCIError(
+            $this->patch,
+            'hash1',
+            'Error1',
+            'https://ci.example.com/1',
+            new \DateTimeImmutable('2024-01-01 10:00:00')
+        );
+        
+        $error2 = new \PatchCIError(
+            $this->patch,
+            'hash2',
+            'Error2',
+            'https://ci.example.com/2',
+            new \DateTimeImmutable('2024-01-01 11:00:00')
+        );
+        
+        $this->assertLessThan($error2->time, $error1->time);
+    }
+}

--- a/tests/Unit/PatchCommentTest.php
+++ b/tests/Unit/PatchCommentTest.php
@@ -1,0 +1,184 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\Unit\Base\UnitTestCase;
+
+
+
+/**
+ * Test suite for PatchComment entity
+ * 
+ * Tests patch comments with user references and timestamps
+ */
+class PatchCommentTest extends UnitTestCase
+{
+    private \Patch $patch;
+    private \User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        
+        // Create a mock patch for testing
+        $this->patch = $this->createMock(\Patch::class);
+        
+        // Create a test user
+        $this->user = new \User(
+            username: 'reviewer1',
+            name: 'Code Reviewer',
+            email: 'reviewer@example.com',
+            photo: '',
+            role: ROLE_PROF,
+            dummy: false
+        );
+    }
+
+    /**
+     * Test patch comment can be created with text and user
+     */
+    public function testPatchCommentCanBeCreatedWithTextAndUser()
+    {
+        $commentText = 'This implementation looks great!';
+        $comment = new \PatchComment($this->patch, $commentText, $this->user);
+        
+        $this->assertInstanceOf(\PatchComment::class, $comment);
+        $this->assertEquals($commentText, $comment->text);
+        $this->assertEquals($this->user, $comment->user);
+        $this->assertEquals($this->patch, $comment->patch);
+    }
+
+    /**
+     * Test patch comment can be created without user
+     */
+    public function testPatchCommentCanBeCreatedWithoutUser()
+    {
+        $commentText = 'Automatic CI comment';
+        $comment = new \PatchComment($this->patch, $commentText);
+        
+        $this->assertEquals($commentText, $comment->text);
+        $this->assertNull($comment->user);
+        $this->assertEquals($this->patch, $comment->patch);
+    }
+
+    /**
+     * Test patch comment sets timestamp on creation
+     */
+    public function testPatchCommentSetsTimestampOnCreation()
+    {
+        $before = new \DateTimeImmutable();
+        $comment = new \PatchComment($this->patch, 'Test comment', $this->user);
+        $after = new \DateTimeImmutable();
+        
+        $this->assertInstanceOf(\DateTimeImmutable::class, $comment->time);
+        $this->assertGreaterThanOrEqual($before, $comment->time);
+        $this->assertLessThanOrEqual($after, $comment->time);
+    }
+
+    /**
+     * Test patch comment text can be very long
+     */
+    public function testPatchCommentTextCanBeVeryLong()
+    {
+        $longText = str_repeat('This is a long comment. ', 1000);
+        $comment = new \PatchComment($this->patch, $longText, $this->user);
+        
+        $this->assertEquals($longText, $comment->text);
+    }
+
+    /**
+     * Test patch comment text can contain special characters
+     */
+    public function testPatchCommentTextCanContainSpecialCharacters()
+    {
+        $specialText = 'Comment with special chars: @#$%^&*()_+-=[]{}|;:,.<>?/`~';
+        $comment = new \PatchComment($this->patch, $specialText, $this->user);
+        
+        $this->assertEquals($specialText, $comment->text);
+    }
+
+    /**
+     * Test patch comment text can contain code snippets
+     */
+    public function testPatchCommentTextCanContainCodeSnippets()
+    {
+        $codeText = <<<'EOT'
+```php
+public function testExample() {
+    $this->assertTrue(true);
+}
+```
+EOT;
+        $comment = new \PatchComment($this->patch, $codeText, $this->user);
+        
+        $this->assertStringContainsString('php', $comment->text);
+        $this->assertStringContainsString('function', $comment->text);
+    }
+
+    /**
+     * Test patch comment can be edited
+     */
+    public function testPatchCommentCanBeEdited()
+    {
+        $originalText = 'Original comment';
+        $comment = new \PatchComment($this->patch, $originalText, $this->user);
+        
+        $newText = 'Updated comment';
+        $comment->text = $newText;
+        
+        $this->assertEquals($newText, $comment->text);
+    }
+
+    /**
+     * Test patch comment user can be changed
+     */
+    public function testPatchCommentUserCanBeChanged()
+    {
+        $comment = new \PatchComment($this->patch, 'Test', $this->user);
+        
+        $newUser = new \User('user2', 'Another User', 'user2@example.com', '', ROLE_STUDENT, false);
+        $comment->user = $newUser;
+        
+        $this->assertEquals($newUser, $comment->user);
+        $this->assertEquals('user2', $comment->user->id);
+    }
+
+    /**
+     * Test patch comment with null user initially
+     */
+    public function testPatchCommentWithNullUserInitially()
+    {
+        $comment = new \PatchComment($this->patch, 'Automated comment');
+        $this->assertNull($comment->user);
+        
+        // Can assign user later
+        $comment->user = $this->user;
+        $this->assertEquals($this->user, $comment->user);
+    }
+
+    /**
+     * Test multiple comments on one patch each receive a creation timestamp
+     */
+    public function testMultipleCommentsReceiveCreationTimestamps()
+    {
+        $before = new \DateTimeImmutable();
+        $comment1 = new \PatchComment($this->patch, 'First comment', $this->user);
+        $comment2 = new \PatchComment($this->patch, 'Second comment', $this->user);
+        $after = new \DateTimeImmutable();
+
+        $this->assertGreaterThanOrEqual($before, $comment1->time);
+        $this->assertLessThanOrEqual($after, $comment1->time);
+        $this->assertGreaterThanOrEqual($before, $comment2->time);
+        $this->assertLessThanOrEqual($after, $comment2->time);
+    }
+
+    /**
+     * Test patch comment empty text
+     */
+    public function testPatchCommentWithEmptyText()
+    {
+        $comment = new \PatchComment($this->patch, '', $this->user);
+        
+        $this->assertEquals('', $comment->text);
+    }
+}

--- a/tests/Unit/PatchFactoryAndReviewIsolatedTest.php
+++ b/tests/Unit/PatchFactoryAndReviewIsolatedTest.php
@@ -1,0 +1,347 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\Unit\Base\UnitTestCase;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+
+
+class PatchFactoryAndReviewIsolatedTest extends UnitTestCase
+{
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testFactoryValidationBranchesAndReviewCommentSuccess()
+    {
+        $cwd = getcwd();
+        $tmp = sys_get_temp_dir() . '/pic1_patch_review_' . bin2hex(random_bytes(4));
+        mkdir($tmp);
+        file_put_contents(
+            $tmp . '/review.php',
+            <<<'PHP'
+<?php
+function review_patch($project_name, $bug_fix, $patch, $patch_description, $issue_url, $issue_description, $coding_standard_url) {
+    $GLOBALS['__review_arguments'] = [
+        'issue_url' => $issue_url,
+        'issue_description' => $issue_description,
+    ];
+    return 'Mock AI review';
+}
+PHP
+        );
+
+        try {
+            chdir($tmp);
+            require_once dirname(__DIR__, 2) . '/entities/Patch.php';
+            $this->defineFakeGitHubPatch();
+
+            $this->assertFactoryPropagatesUpdateException();
+            $this->assertFactoryThrows('invalidAfterStats', 'Patch not found');
+            $this->assertFactoryThrows('valid', 'Empty description', '');
+            $this->assertFactoryThrows('noAuthors', 'Patch has no recognized authors');
+            $this->assertFactoryThrows('mainBranch', 'Invalid branch name: main');
+            $this->assertFactoryThrows('noCommits', 'No commit found in the given branch');
+            $this->assertFactoryThrows(
+                'valid',
+                'Duplicated patch',
+                'Patch description',
+                static function (\ProjGroup $group): void {
+                    $group->patches->add(new \GitHub\GitHubPatch());
+                }
+            );
+            $this->assertFactoryThrows('trailingWhitespace', 'has trailing whitespace');
+            $this->assertFactoryThrows('missingNewline', 'is missing a newline at the end');
+            $this->assertFactoryThrows('invalidEmail', 'Invalid email used in commit');
+            $this->assertFactoryThrows('mergeCommit', 'Merge commits are not allowed');
+            $this->assertFactoryThrows(
+                'valid',
+                'Missing signature in a project with DCO.',
+                'Patch description',
+                static function (\ProjGroup $group): void {
+                    $group->dco = true;
+                }
+            );
+            $this->assertFactoryThrows('invalidCoauthor', 'Invalid Co-authored-by line');
+            $this->assertFactoryThrows('coauthorNotAtEnd', 'Co-authored-by lines must be at the end');
+            $this->assertFactoryThrows('shortMessage', 'Commit message is too short');
+            $this->assertFactoryThrows('shortLines', 'Most lines of the commit message are too short');
+            $this->assertFactoryThrows(
+                'missingIssueReference',
+                'No commit message references the issue #id',
+                'Patch description',
+                static function (\ProjGroup $group): void {
+                    $group->url_proposal = 'https://github.com/mockorg/mockrepo/issues/42';
+                }
+            );
+
+            \GitHub\GitHubPatch::$mode = 'trailingWhitespace';
+            [$ignoredGroup, $ignoredSubmitter] = $this->factoryFixture();
+            $ignoredPatch = \Patch::factory(
+                $ignoredGroup,
+                'https://github.com/mockorg/mockrepo/compare/main...mockorg:mockrepo:feature-branch',
+                \PatchType::Feature,
+                'Patch description',
+                $ignoredSubmitter,
+                '',
+                true
+            );
+            $this->assertStringContainsString(
+                'Failed validation:',
+                $ignoredPatch->comments[1]->text
+            );
+            $this->assertStringContainsString(
+                'has trailing whitespace',
+                $ignoredPatch->comments[1]->text
+            );
+
+            \GitHub\GitHubPatch::$mode = 'valid';
+            [$group, $submitter] = $this->factoryFixture();
+            $group->url_proposal = 'https://github.com/mockorg/mockrepo/issues/42';
+            $this->replaceCachedGitHubClient(new class {
+                public function api($endpoint) {
+                    return new class {
+                        public function show($org, $repo, $number) {
+                            return [
+                                'title' => 'Stub issue title',
+                                'body' => 'Stub issue description',
+                            ];
+                        }
+                    };
+                }
+            });
+
+            $patch = \Patch::factory(
+                $group,
+                'https://github.com/mockorg/mockrepo/compare/main...mockorg:mockrepo:feature-branch',
+                \PatchType::Feature,
+                "  Patch description  ",
+                $submitter
+            );
+
+            $this->assertEquals('mockhash', $patch->hash);
+            $this->assertCount(2, $patch->comments);
+            $this->assertStringContainsString(
+                "Patch submitted; hash: \n\nPatch description",
+                $patch->comments->first()->text
+            );
+            $this->assertStringContainsString('Mock AI review', $patch->comments->last()->text);
+            $this->assertStringContainsString('Commit: mockhash', $patch->comments->last()->text);
+            $this->assertSame(
+                'https://github.com/mockorg/mockrepo/issues/42',
+                $GLOBALS['__review_arguments']['issue_url']
+            );
+            $this->assertSame(
+                "Stub issue title\nStub issue description",
+                $GLOBALS['__review_arguments']['issue_description']
+            );
+        } finally {
+            chdir($cwd);
+            @unlink($tmp . '/review.php');
+            @rmdir($tmp);
+        }
+    }
+
+    private function assertFactoryThrows(
+        string $mode,
+        string $message,
+        string $description = 'Patch description',
+        ?callable $configureGroup = null
+    ): void {
+        \GitHub\GitHubPatch::$mode = $mode;
+        [$group, $submitter] = $this->factoryFixture();
+        if ($configureGroup !== null) {
+            $configureGroup($group);
+        }
+
+        try {
+            \Patch::factory(
+                $group,
+                'https://github.com/mockorg/mockrepo/compare/main...mockorg:mockrepo:feature-branch',
+                \PatchType::Feature,
+                $description,
+                $submitter
+            );
+            $this->fail("Factory mode $mode should throw");
+        } catch (\ValidationException $exception) {
+            $this->assertStringContainsString($message, $exception->getMessage());
+        }
+    }
+
+    private function assertFactoryPropagatesUpdateException(): void
+    {
+        \GitHub\GitHubPatch::$mode = 'updateThrows';
+        [$group, $submitter] = $this->factoryFixture();
+
+        try {
+            \Patch::factory(
+                $group,
+                'https://github.com/mockorg/mockrepo/compare/main...mockorg:mockrepo:feature-branch',
+                \PatchType::Feature,
+                'Patch description',
+                $submitter
+            );
+            $this->fail('Factory should propagate an unexpected update failure');
+        } catch (\Exception $exception) {
+            $this->assertSame('temporary', $exception->getMessage());
+        }
+    }
+
+    private function factoryFixture(): array
+    {
+        $shift = new \Shift('T01', 2026);
+        $group = new \ProjGroup(1, 2026, $shift);
+        $group->repository = 'github:mockorg/mockrepo';
+        $group->project_name = 'Mock Project';
+
+        $submitter = new \User(
+            'mockuser',
+            'Mock User',
+            'ist12345@tecnico.ulisboa.pt',
+            '',
+            ROLE_STUDENT,
+            false
+        );
+        $submitter->repository_user = 'github:mockuser';
+        $group->addStudent($submitter);
+
+        return [$group, $submitter];
+    }
+
+    private function defineFakeGitHubPatch(): void
+    {
+        if (class_exists('\\GitHub\\GitHubPatch', false)) {
+            return;
+        }
+
+        eval(<<<'PHP'
+namespace GitHub;
+
+class GitHubPatch extends \Patch
+{
+    public static string $mode = 'valid';
+
+    public static function construct($url, \Repository $repository)
+    {
+        return new self();
+    }
+
+    public function updateStats()
+    {
+        if (self::$mode === 'updateThrows') {
+            throw new \Exception('temporary');
+        }
+
+        $this->hash = 'mockhash';
+        $this->lines_added = 1;
+        $this->lines_deleted = 1;
+        $this->files_modified = 1;
+
+        if (self::$mode === 'noAuthors') {
+            $this->students = [];
+        } elseif (!$this->group->students->isEmpty()) {
+            $this->students->add($this->group->students->first());
+        }
+    }
+
+    public function isValid(): bool
+    {
+        return self::$mode !== 'invalidAfterStats';
+    }
+
+    public function branch(): string
+    {
+        return self::$mode === 'mainBranch' ? 'main' : 'feature-branch';
+    }
+
+    public function origin(): string
+    {
+        return 'mockorg:mockrepo:feature-branch';
+    }
+
+    public function commits(): array
+    {
+        if (self::$mode === 'noCommits') {
+            return [];
+        }
+
+        $email = self::$mode === 'invalidEmail'
+            ? 'not-an-email'
+            : 'ist12345@tecnico.ulisboa.pt';
+        $message = match (self::$mode) {
+            'mergeCommit' => 'Merge branch feature into main with enough explanatory detail.',
+            'invalidCoauthor' => "Implement feature with complete detail.\nCo-authored by: Other <other@example.com>",
+            'coauthorNotAtEnd' => "Implement feature with complete detail.\nCo-authored-by: Other <other@example.com>\nAdditional trailing explanation.",
+            'shortMessage' => 'Too short',
+            'shortLines' => "Tiny line\nTiny line\nTiny line\nA substantially longer explanation for this feature.",
+            'missingIssueReference' => 'Implement feature with enough detail but without issue reference.',
+            default => 'Implement feature for issue #42 with enough detail for testing.',
+        };
+        $coauthors = self::$mode === 'coauthorNotAtEnd'
+            ? [['', 'Other', 'other@example.com']]
+            : [];
+
+        return [[
+            'username' => 'mockuser',
+            'name' => 'Mock User',
+            'email' => $email,
+            'message' => $message,
+            'co-authored' => $coauthors,
+        ]];
+    }
+
+    public function diff(): array
+    {
+        $patch = match (self::$mode) {
+            'trailingWhitespace' => "+Added line \n",
+            'missingNewline' => "+Added line\n\\ No newline at end of file",
+            default => "+Added line\n-Removed line\n",
+        };
+
+        return [[
+            'filename' => 'file1.php',
+            'patch' => $patch,
+        ]];
+    }
+
+    public function patch(): string
+    {
+        return "diff --git a/file1.php b/file1.php\n+Added line\n";
+    }
+
+    protected function computeBranchHash(): string
+    {
+        return 'mockhash';
+    }
+
+    protected function computeLinesAdded(): int
+    {
+        return 1;
+    }
+
+    protected function computeLinesDeleted(): int
+    {
+        return 1;
+    }
+
+    protected function computeFilesModified(): int
+    {
+        return 1;
+    }
+
+    public function getPatchURL(): string
+    {
+        return 'https://github.com/mockorg/mockrepo/compare/main...mockorg:mockrepo:feature-branch';
+    }
+
+    public function getCommitURL(string $hash): string
+    {
+        return "https://github.com/mockorg/mockrepo/commit/$hash";
+    }
+
+    public function setPR(\PullRequest $pr): void {}
+    public function findAndSetPR(): bool { return false; }
+    public function getPR(): ?\PullRequest { return null; }
+}
+PHP);
+    }
+}

--- a/tests/Unit/PatchTest.php
+++ b/tests/Unit/PatchTest.php
@@ -1,0 +1,557 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\Unit\Base\UnitTestCase;
+use Tests\Mocks\FakePatch;
+use Tests\Mocks\FakePullRequest;
+use Tests\Mocks\FakeQueryResultEntityManager;
+
+
+
+// Explicitly require Patch.php to load enums
+require_once dirname(__DIR__, 2) . '/entities/Patch.php';
+
+/**
+ * Test suite for Patch entity and enums
+ * 
+ * Tests PatchStatus enum, PatchType enum, and the complex Patch factory method
+ */
+class PatchTest extends UnitTestCase
+{
+    /**
+     * Test PatchStatus enum values
+     */
+    public function testPatchStatusEnumValues()
+    {
+        $this->assertEquals(0, \PatchStatus::WaitingReview->value);
+        $this->assertEquals(1, \PatchStatus::Reviewed->value);
+        $this->assertEquals(2, \PatchStatus::Approved->value);
+        $this->assertEquals(3, \PatchStatus::PROpen->value);
+        $this->assertEquals(4, \PatchStatus::PROpenIllegal->value);
+        $this->assertEquals(5, \PatchStatus::Merged->value);
+        $this->assertEquals(6, \PatchStatus::MergedIllegal->value);
+        $this->assertEquals(7, \PatchStatus::NotMerged->value);
+        $this->assertEquals(8, \PatchStatus::NotMergedIllegal->value);
+        $this->assertEquals(9, \PatchStatus::Closed->value);
+    }
+
+    /**
+     * Test PatchStatus enum labels
+     */
+    public function testPatchStatusEnumLabels()
+    {
+        $this->assertEquals('waiting review', \PatchStatus::WaitingReview->label());
+        $this->assertEquals('reviewed (not approved)', \PatchStatus::Reviewed->label());
+        $this->assertEquals('approved', \PatchStatus::Approved->label());
+        $this->assertEquals('PR open', \PatchStatus::PROpen->label());
+        $this->assertEquals('PR open wo/ approval', \PatchStatus::PROpenIllegal->label());
+        $this->assertEquals('merged', \PatchStatus::Merged->label());
+        $this->assertEquals('merged wo/ approval', \PatchStatus::MergedIllegal->label());
+        $this->assertEquals('closed, not merged', \PatchStatus::NotMerged->label());
+        $this->assertEquals('closed, not merged wo/ approval', \PatchStatus::NotMergedIllegal->label());
+        $this->assertEquals('closed', \PatchStatus::Closed->label());
+    }
+
+    /**
+     * Test PatchType enum values
+     */
+    public function testPatchTypeEnumValues()
+    {
+        $this->assertEquals(0, \PatchType::BugFix->value);
+        $this->assertEquals(1, \PatchType::Feature->value);
+    }
+
+    /**
+     * Test PatchType enum labels
+     */
+    public function testPatchTypeEnumLabels()
+    {
+        $this->assertEquals('bug fix', \PatchType::BugFix->label());
+        $this->assertEquals('feature', \PatchType::Feature->label());
+    }
+
+    /**
+     * Test Patch factory throws exception when group has no repository
+     */
+    public function testPatchFactoryThrowsExceptionWhenGroupHasNoRepository()
+    {
+        $this->expectException(\ValidationException::class);
+        $this->expectExceptionMessage('Group has no repository yet');
+
+        $shift = new \Shift('T01', 2024);
+        $group = new \ProjGroup(1, 2024, $shift);
+        $user = new \User(
+            username: 'testuser',
+            name: 'Test User',
+            email: 'test@example.com',
+            photo: '',
+            role: ROLE_STUDENT,
+            dummy: false
+        );
+
+        // Group has no repository, so factory should throw
+        \Patch::factory($group, 'https://github.com/test/repo/compare/main...test:branch:feature',
+                       \PatchType::Feature, 'Test patch', $user);
+    }
+
+    /**
+     * Test PatchStatus default value
+     */
+    public function testPatchStatusDefaultValue()
+    {
+        $patch = $this->createConcretePatchMock();
+
+        $this->assertSame(\PatchStatus::WaitingReview, $patch->status);
+    }
+
+    /**
+     * Test that Patch class is abstract
+     */
+    public function testPatchIsAbstract()
+    {
+        $reflection = new \ReflectionClass(\Patch::class);
+        $this->assertTrue($reflection->isAbstract());
+    }
+
+    /**
+     * Test Patch factory is static
+     */
+    public function testPatchFactoryMethodIsStatic()
+    {
+        $reflection = new \ReflectionClass(\Patch::class);
+        $method = $reflection->getMethod('factory');
+        
+        $this->assertTrue($method->isStatic());
+    }
+
+    /**
+     * Test DONT_WANT_ISSUE_IN_COMMIT_MSG constant is defined
+     */
+    public function testDontWantIssueInCommitMsgConstantExists()
+    {
+        $this->assertTrue(defined('DONT_WANT_ISSUE_IN_COMMIT_MSG'));
+        
+        $constant = constant('DONT_WANT_ISSUE_IN_COMMIT_MSG');
+        $this->assertIsArray($constant);
+        
+        // Verify expected entries exist
+        $this->assertArrayHasKey('github:ArduPilot/ardupilot', $constant);
+        $this->assertArrayHasKey('github:godotengine/godot', $constant);
+        $this->assertArrayHasKey('github:oppia/oppia', $constant);
+    }
+
+    /**
+     * Test concrete Patch methods with mock implementation
+     */
+    public function testPatchGetStatusReturnsLabel()
+    {
+        $patch = $this->createConcretePatchMock();
+        $patch->status = \PatchStatus::Approved;
+        
+        $this->assertEquals('approved', $patch->getStatus());
+    }
+
+    /**
+     * Test Patch getType returns label
+     */
+    public function testPatchGetTypeReturnsLabel()
+    {
+        $patch = $this->createConcretePatchMock();
+        $patch->type = \PatchType::BugFix;
+        
+        $this->assertEquals('bug fix', $patch->getType());
+    }
+
+    /**
+     * Test Patch isStillOpen returns true for pending statuses
+     */
+    public function testPatchIsStillOpenForPendingStatus()
+    {
+        $patch = $this->createConcretePatchMock();
+        $patch->status = \PatchStatus::Approved;
+        
+        $this->assertTrue($patch->isStillOpen());
+    }
+
+    /**
+     * Test Patch isStillOpen returns false for merged status
+     */
+    public function testPatchIsNotStillOpenForMergedStatus()
+    {
+        $patch = $this->createConcretePatchMock();
+        $patch->status = \PatchStatus::Merged;
+        
+        $this->assertFalse($patch->isStillOpen());
+    }
+
+    /**
+     * Test Patch wasMerged returns true for merged status
+     */
+    public function testPatchWasMergedReturnsTrueForMergedStatus()
+    {
+        $patch = $this->createConcretePatchMock();
+        $patch->status = \PatchStatus::Merged;
+        
+        $this->assertTrue($patch->wasMerged());
+    }
+
+    /**
+     * Test Patch wasMerged returns true for merged illegal status
+     */
+    public function testPatchWasMergedReturnsTrueForMergedIllegalStatus()
+    {
+        $patch = $this->createConcretePatchMock();
+        $patch->status = \PatchStatus::MergedIllegal;
+        
+        $this->assertTrue($patch->wasMerged());
+    }
+
+    /**
+     * Test Patch wasMerged returns false for unmerged status
+     */
+    public function testPatchWasMergedReturnsFalseForUnmergedStatus()
+    {
+        $patch = $this->createConcretePatchMock();
+        $patch->status = \PatchStatus::NotMerged;
+        
+        $this->assertFalse($patch->wasMerged());
+    }
+
+    /**
+     * Test Patch getPRURL returns null when no PR
+     */
+    public function testPatchGetPRUrlReturnsNullWhenNoPR()
+    {
+        $patch = $this->createConcretePatchMock();
+        
+        $this->assertNull($patch->getPRURL());
+    }
+
+    /**
+     * Test Patch constructor initializes collections
+     */
+    public function testPatchConstructorInitializesCollections()
+    {
+        $patch = $this->createConcretePatchMock();
+        
+        $this->assertInstanceOf(\Doctrine\Common\Collections\ArrayCollection::class, $patch->comments);
+        $this->assertInstanceOf(\Doctrine\Common\Collections\ArrayCollection::class, $patch->ci_failures);
+        $this->assertInstanceOf(\Doctrine\Common\Collections\ArrayCollection::class, $patch->students);
+        $this->assertTrue($patch->comments->isEmpty());
+        $this->assertTrue($patch->ci_failures->isEmpty());
+        $this->assertTrue($patch->students->isEmpty());
+    }
+
+    /**
+     * Helper to create a concrete Patch implementation for testing
+     */
+    private function createConcretePatchMock(): \Patch
+    {
+        return new FakePatch(patchCommits: [
+            ['username' => 'user1', 'name' => 'User One', 'email' => 'user1@example.com', 'message' => 'First commit', 'co-authored' => []],
+            ['username' => 'user2', 'name' => 'User Two', 'email' => 'user2@example.com', 'message' => 'Second commit', 'co-authored' => [['user1', 'User One', 'user1@example.com'], ['user3', 'User Three', 'user3@example.com']]],
+        ]);
+    }
+
+    /**
+     * Test Patch allAuthors returns list of unique authors from commits
+     */
+    public function testPatchAllAuthorsReturnsUniqueCommitAuthors()
+    {
+        $patch = $this->createConcretePatchMock();
+        $authors = $patch->allAuthors();
+
+        $this->assertSame([
+            ['user1', 'User One', 'user1@example.com'],
+            ['user2', 'User Two', 'user2@example.com'],
+            ['user3', 'User Three', 'user3@example.com'],
+        ], array_values($authors));
+    }
+
+    /**
+     * Test Patch factory is static and public
+     */
+    public function testPatchFactoryMethodSignature()
+    {
+        $reflection = new \ReflectionClass(\Patch::class);
+        $method = $reflection->getMethod('factory');
+        
+        $this->assertTrue($method->isStatic());
+        $this->assertTrue($method->isPublic());
+        
+        // Check parameters
+        $params = $method->getParameters();
+        $this->assertGreaterThanOrEqual(4, count($params));
+    }
+
+    /**
+     * Test Patch getIssueURL for feature type
+     */
+    public function testPatchGetIssueURLForFeatureType()
+    {
+        $shift = new \Shift('T01', 2024);
+        $group = new \ProjGroup(1, 2024, $shift);
+        $group->url_proposal = 'https://github.com/example/repo/issues/1';
+        
+        $patch = $this->createConcretePatchMock();
+        $patch->group = $group;
+        $patch->type = \PatchType::Feature;
+        
+        $this->assertEquals('https://github.com/example/repo/issues/1', $patch->getIssueURL());
+    }
+
+    /**
+     * Test Patch getIssue returns null for feature type without proposal
+     */
+    public function testPatchGetIssueReturnsNullForFeatureTypeWithoutProposal()
+    {
+        $shift = new \Shift('T01', 2024);
+        $group = new \ProjGroup(1, 2024, $shift);
+        $group->url_proposal = ''; // Empty string, not null
+        
+        $patch = $this->createConcretePatchMock();
+        $patch->group = $group;
+        $patch->type = \PatchType::Feature;
+        
+        $result = $patch->getIssue();
+        // Empty string should result in null
+        $this->assertNull($result);
+    }
+
+    /**
+     * Test Patch getSubmitter returns user from first comment
+     */
+    public function testPatchGetSubmitterReturnsUserFromFirstComment()
+    {
+        $user = new \User(
+            username: 'testuser',
+            name: 'Test User',
+            email: 'test@example.com',
+            photo: '',
+            role: ROLE_STUDENT,
+            dummy: false
+        );
+        
+        $patch = $this->createConcretePatchMock();
+        $comment = new \PatchComment($patch, 'Test comment', $user);
+        $patch->comments->add($comment);
+        
+        $this->assertEquals($user, $patch->getSubmitter());
+    }
+
+    /**
+     * Test Patch getSubmitterName returns submitter's short name
+     */
+    public function testPatchGetSubmitterNameReturnsShortName()
+    {
+        $user = new \User(
+            username: 'testuser',
+            name: 'Test User',
+            email: 'test@example.com',
+            photo: '',
+            role: ROLE_STUDENT,
+            dummy: false
+        );
+        
+        $patch = $this->createConcretePatchMock();
+        $comment = new \PatchComment($patch, 'Test comment', $user);
+        $patch->comments->add($comment);
+        
+        $this->assertEquals($user->shortName(), $patch->getSubmitterName());
+    }
+
+    /**
+     * Test Patch getHashes returns all hashes including current
+     */
+    public function testPatchGetHashesReturnsAllHashes()
+    {
+        $user = new \User(
+            username: 'testuser',
+            name: 'Test User',
+            email: 'test@example.com',
+            photo: '',
+            role: ROLE_STUDENT,
+            dummy: false
+        );
+        
+        $patch = $this->createConcretePatchMock();
+        $patch->hash = 'current_hash_123';
+        
+        // Add comment with hash reference
+        $comment = new \PatchComment($patch, 'New branch hash: old_hash_456', $user);
+        $patch->comments->add($comment);
+        
+        $hashes = $patch->getHashes();
+        
+        $this->assertContains('old_hash_456', $hashes);
+        $this->assertContains('current_hash_123', $hashes);
+    }
+
+    /**
+     * Test Patch addCIError adds error to ci_failures collection
+     */
+    public function testPatchAddCIErrorAddsToCollection()
+    {
+        $patch = $this->createConcretePatchMock();
+        $time = new \DateTimeImmutable();
+        
+        $patch->addCIError('abc123', 'TestError', 'https://ci.example.com/error', $time);
+        
+        $this->assertTrue($patch->ci_failures->count() === 1);
+        
+        $error = $patch->ci_failures->first();
+        $this->assertInstanceOf(\PatchCIError::class, $error);
+        $this->assertEquals('abc123', $error->hash);
+        $this->assertEquals('TestError', $error->name);
+    }
+
+    /**
+     * Test Patch addCIError prevents duplicates
+     */
+    public function testPatchAddCIErrorPreventsDuplicates()
+    {
+        $patch = $this->createConcretePatchMock();
+        $time = new \DateTimeImmutable();
+        
+        $patch->addCIError('abc123', 'TestError', 'https://ci.example.com/error1', $time);
+        $patch->addCIError('abc123', 'TestError', 'https://ci.example.com/error2', $time);
+        
+        // Should still be 1 error, not 2
+        $this->assertTrue($patch->ci_failures->count() === 1);
+    }
+
+    /**
+     * Test Patch set_video_url stores valid URL
+     */
+    public function testPatchSetVideoUrlStoresValidUrl()
+    {
+        $patch = $this->createConcretePatchMock();
+        
+        // Test with empty URL (should be valid)
+        $patch->set_video_url('');
+        $this->assertEquals('', $patch->video_url);
+    }
+
+    /**
+     * Test Patch updateStats handles valid patch
+     */
+    public function testPatchUpdateStatsWithValidPatch()
+    {
+        $shift = new \Shift('T01', 2024);
+        $group = new \ProjGroup(1, 2024, $shift);
+        
+        $patch = $this->createConcretePatchMock();
+        $patch->group = $group;
+        $patch->status = \PatchStatus::WaitingReview;
+        
+        // updateStats should work without errors for valid patch
+        $patch->updateStats();
+        
+        // Hash should be computed
+        $this->assertEquals('abc123', $patch->hash);
+    }
+
+    public function testPatchAddReviewCommentReturnsNullWhenHashAlreadyReviewed()
+    {
+        $patch = $this->createConcretePatchMock();
+        $patch->hash = 'abc123';
+        $patch->comments->add(new \PatchComment(
+            $patch,
+            "🤖 AI-generated feedback — please review carefully\nCommit: abc123\n\nAlready reviewed"
+        ));
+
+        $this->assertNull($patch->add_patch_review_comment());
+        $this->assertCount(1, $patch->comments);
+    }
+
+    public function testPatchUpdateStatsUsesPullRequestData()
+    {
+        $patch = $this->createPatchWithState(true, $this->createPullRequestMock(true, false));
+        $patch->status = \PatchStatus::Approved;
+
+        $patch->updateStats();
+
+        $this->assertEquals(\PatchStatus::Merged, $patch->status);
+        $this->assertEquals(12, $patch->lines_added);
+        $this->assertEquals(3, $patch->lines_deleted);
+        $this->assertEquals(2, $patch->files_modified);
+    }
+
+    public function testPatchUpdateStatsUsesClosedPullRequestData()
+    {
+        $patch = $this->createPatchWithState(true, $this->createPullRequestMock(false, true));
+        $patch->status = \PatchStatus::WaitingReview;
+
+        $patch->updateStats();
+
+        $this->assertEquals(\PatchStatus::NotMergedIllegal, $patch->status);
+        $this->assertEquals(12, $patch->lines_added);
+        $this->assertEquals(3, $patch->lines_deleted);
+        $this->assertEquals(2, $patch->files_modified);
+    }
+
+    public function testPatchUpdateStatsHandlesDeletedBranchStatuses()
+    {
+        $patch = $this->createPatchWithState(false);
+        $patch->status = \PatchStatus::PROpenIllegal;
+        $patch->updateStats();
+        $this->assertEquals(\PatchStatus::NotMergedIllegal, $patch->status);
+        $this->assertEquals(0, $patch->lines_added);
+
+        $patch = $this->createPatchWithState(false);
+        $patch->status = \PatchStatus::PROpen;
+        $patch->updateStats();
+        $this->assertEquals(\PatchStatus::NotMerged, $patch->status);
+
+        $patch = $this->createPatchWithState(false);
+        $patch->status = \PatchStatus::Reviewed;
+        $patch->updateStats();
+        $this->assertEquals(\PatchStatus::Closed, $patch->status);
+    }
+
+    public function testPatchGetIssueURLForBugFixType()
+    {
+        global $entityManager;
+        $oldEntityManager = $entityManager ?? null;
+
+        $bug = new \SelectedBug();
+        $bug->issue_url = 'https://github.com/mockorg/mockrepo/issues/7';
+        $entityManager = new FakeQueryResultEntityManager($bug);
+
+        $shift = new \Shift('T01', 2024);
+        $group = new \ProjGroup(1, 2024, $shift);
+        $user = new \User('testuser', 'Test User', 'test@example.com', '', ROLE_STUDENT, false);
+
+        $patch = $this->createConcretePatchMock();
+        $patch->group = $group;
+        $patch->type = \PatchType::BugFix;
+        $patch->comments->add(new \PatchComment($patch, 'Patch submitted', $user));
+
+        try {
+            $this->assertEquals('https://github.com/mockorg/mockrepo/issues/7', $patch->getIssueURL());
+        } finally {
+            $entityManager = $oldEntityManager;
+        }
+    }
+
+    private function createPatchWithState(bool $valid, ?\PullRequest $pr = null): \Patch
+    {
+        return new FakePatch(valid: $valid, pullRequest: $pr);
+    }
+
+    private function createPullRequestMock(bool $merged, bool $closed): \PullRequest
+    {
+        return new FakePullRequest(
+            branchUrl: 'https://github.com/mockorg/mockrepo/tree/feature',
+            pullRequestOrigin: 'mockorg:mockrepo:feature',
+            closed: $closed,
+            merged: $merged,
+            merger: 'mockuser',
+            addedLines: 12,
+            deletedLines: 3,
+            modifiedFiles: 2
+        );
+    }
+
+}

--- a/tests/Unit/ProjGroupTest.php
+++ b/tests/Unit/ProjGroupTest.php
@@ -1,0 +1,443 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\Unit\Base\UnitTestCase;
+use Tests\Mocks\FakeQueryResultEntityManager;
+
+
+
+/**
+ * Test suite for ProjGroup entity
+ * 
+ * Tests project group properties, repository information, and project details
+ */
+class ProjGroupTest extends UnitTestCase
+{
+    private \ProjGroup $group;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $shift = new \Shift('T01', 2024);
+        $this->group = new \ProjGroup(1, 2024, $shift);
+    }
+
+    /**
+     * Test project group can be created
+     */
+    public function testProjGroupCanBeCreated()
+    {
+        $this->assertInstanceOf(\ProjGroup::class, $this->group);
+    }
+
+    /**
+     * Test group number can be set and retrieved
+     */
+    public function testGroupNumberCanBeSetAndRetrieved()
+    {
+        $this->assertEquals(1, $this->group->group_number);
+        
+        $this->group->group_number = 5;
+        $this->assertEquals(5, $this->group->group_number);
+    }
+
+    /**
+     * Test year can be set and retrieved
+     */
+    public function testYearCanBeSetAndRetrieved()
+    {
+        $this->assertEquals(2024, $this->group->year);
+        
+        $this->group->year = 2025;
+        $this->assertEquals(2025, $this->group->year);
+    }
+
+    /**
+     * Test project name can be set and retrieved
+     */
+    public function testProjectNameCanBeSetAndRetrieved()
+    {
+        $projectName = 'Example Project';
+        $this->group->project_name = $projectName;
+        
+        $this->assertEquals($projectName, $this->group->project_name);
+    }
+
+    /**
+     * Test project description can be set and retrieved
+     */
+    public function testProjectDescriptionCanBeSetAndRetrieved()
+    {
+        $description = 'This is a comprehensive description of the project';
+        $this->group->project_description = $description;
+        
+        $this->assertEquals($description, $this->group->project_description);
+    }
+
+    /**
+     * Test project website can be set and retrieved
+     */
+    public function testProjectWebsiteCanBeSetAndRetrieved()
+    {
+        $website = 'https://example-project.org';
+        $this->group->project_website = $website;
+        
+        $this->assertEquals($website, $this->group->project_website);
+    }
+
+    /**
+     * Test repository URL can be set and retrieved
+     */
+    public function testRepositoryCanBeSetAndRetrieved()
+    {
+        $repo = 'https://github.com/example/project';
+        $this->group->repository = $repo;
+        
+        $this->assertEquals($repo, $this->group->repository);
+    }
+
+    /**
+     * Test CLA flag can be set and retrieved
+     */
+    public function testCLAFlagCanBeSetAndRetrieved()
+    {
+        $this->assertFalse($this->group->cla);
+        
+        $this->group->cla = true;
+        $this->assertTrue($this->group->cla);
+    }
+
+    /**
+     * Test DCO flag can be set and retrieved
+     */
+    public function testDCOFlagCanBeSetAndRetrieved()
+    {
+        $this->assertFalse($this->group->dco);
+        
+        $this->group->dco = true;
+        $this->assertTrue($this->group->dco);
+    }
+
+    /**
+     * Test major users can be set and retrieved
+     */
+    public function testMajorUsersCanBeSetAndRetrieved()
+    {
+        $majorUsers = 'Apache, OpenStack, Google';
+        $this->group->major_users = $majorUsers;
+        
+        $this->assertEquals($majorUsers, $this->group->major_users);
+    }
+
+    /**
+     * Test coding style link can be set and retrieved
+     */
+    public function testCodingStyleLinkCanBeSetAndRetrieved()
+    {
+        $link = 'https://example.org/coding-style';
+        $this->group->coding_style = $link;
+        
+        $this->assertEquals($link, $this->group->coding_style);
+    }
+
+    /**
+     * Test bugs for beginners link can be set and retrieved
+     */
+    public function testBugsForBeginnersLinkCanBeSetAndRetrieved()
+    {
+        $link = 'https://example.org/issues?label=beginner';
+        $this->group->bugs_for_beginners = $link;
+        
+        $this->assertEquals($link, $this->group->bugs_for_beginners);
+    }
+
+    /**
+     * Test project ideas link can be set and retrieved
+     */
+    public function testProjectIdeasLinkCanBeSetAndRetrieved()
+    {
+        $link = 'https://example.org/ideas';
+        $this->group->project_ideas = $link;
+        
+        $this->assertEquals($link, $this->group->project_ideas);
+    }
+
+    /**
+     * Test student programs can be set and retrieved
+     */
+    public function testStudentProgramsCanBeSetAndRetrieved()
+    {
+        $programs = 'GSoC, Outreachy, LFX';
+        $this->group->student_programs = $programs;
+        
+        $this->assertEquals($programs, $this->group->student_programs);
+    }
+
+    /**
+     * Test getting started manual link can be set and retrieved
+     */
+    public function testGettingStartedManualLinkCanBeSetAndRetrieved()
+    {
+        $link = 'https://example.org/getting-started';
+        $this->group->getting_started_manual = $link;
+        
+        $this->assertEquals($link, $this->group->getting_started_manual);
+    }
+
+    /**
+     * Test developers manual link can be set and retrieved
+     */
+    public function testDevelopersManualLinkCanBeSetAndRetrieved()
+    {
+        $link = 'https://example.org/developers';
+        $this->group->developers_manual = $link;
+        
+        $this->assertEquals($link, $this->group->developers_manual);
+    }
+
+    /**
+     * Test testing manual link can be set and retrieved
+     */
+    public function testTestingManualLinkCanBeSetAndRetrieved()
+    {
+        $link = 'https://example.org/testing';
+        $this->group->testing_manual = $link;
+        
+        $this->assertEquals($link, $this->group->testing_manual);
+    }
+
+    /**
+     * Test developers mailing list can be set and retrieved
+     */
+    public function testDeveloperMailingListCanBeSetAndRetrieved()
+    {
+        $list = 'https://example.org/mailing-list';
+        $this->group->developers_mailing_list = $list;
+        
+        $this->assertEquals($list, $this->group->developers_mailing_list);
+    }
+
+    /**
+     * Test patch submission link can be set and retrieved
+     */
+    public function testPatchSubmissionLinkCanBeSetAndRetrieved()
+    {
+        $link = 'https://example.org/patch-submission';
+        $this->group->patch_submission = $link;
+        
+        $this->assertEquals($link, $this->group->patch_submission);
+    }
+
+    /**
+     * Test hash proposal file can be set and retrieved
+     */
+    public function testHashProposalFileCanBeSetAndRetrieved()
+    {
+        $hash = 'abc123def456ghi789';
+        $this->group->hash_proposal_file = $hash;
+        
+        $this->assertEquals($hash, $this->group->hash_proposal_file);
+    }
+
+    /**
+     * Test default project website value
+     */
+    public function testDefaultProjectWebsite()
+    {
+        $shift = new \Shift('T02', 2024);
+        $newGroup = new \ProjGroup(2, 2024, $shift);
+        $this->assertEquals('https://example.org', $newGroup->project_website);
+    }
+
+    /**
+     * Test default links
+     */
+    public function testDefaultLinks()
+    {
+        $shift = new \Shift('T03', 2024);
+        $newGroup = new \ProjGroup(3, 2024, $shift);
+        $this->assertEquals('https://example.org', $newGroup->coding_style);
+        $this->assertEquals('https://example.org', $newGroup->bugs_for_beginners);
+        $this->assertEquals('https://example.org', $newGroup->project_ideas);
+        $this->assertEquals('https://example.org', $newGroup->getting_started_manual);
+        $this->assertEquals('https://example.org', $newGroup->developers_manual);
+        $this->assertEquals('https://example.org', $newGroup->testing_manual);
+        $this->assertEquals('https://example.org', $newGroup->patch_submission);
+    }
+
+    public function testResetStudentsRemovesGroupFromStudents()
+    {
+        $student1 = new \User('ist10001', 'Test Student One', 'ist10001@tecnico.ulisboa.pt', '', ROLE_STUDENT, false);
+        $student2 = new \User('ist10002', 'Test Student Two', 'ist10002@tecnico.ulisboa.pt', '', ROLE_STUDENT, false);
+
+        $this->group->addStudent($student1);
+        $this->group->addStudent($student2);
+
+        $this->group->resetStudents();
+
+        $this->assertTrue($this->group->students->isEmpty());
+        $this->assertFalse($student1->groups->contains($this->group));
+        $this->assertFalse($student2->groups->contains($this->group));
+    }
+
+    public function testRepositoryHelpersReturnRepositoryData()
+    {
+        $this->group->repository = 'github:mockorg/mockrepo';
+
+        $repository = $this->group->getRepository();
+
+        $this->assertInstanceOf(\Repository::class, $repository);
+        $this->assertEquals('github:mockorg/mockrepo', $this->group->getRepositoryId());
+        $this->assertEquals('github:mockorg/mockrepo', $this->group->getValidRepository()?->id);
+        $this->assertEquals('https://github.com/mockorg/mockrepo', $this->group->getstr_repository());
+    }
+
+    public function testRepositoryHelpersHandleEmptyRepository()
+    {
+        $this->group->repository = '';
+
+        $this->assertNull($this->group->getRepository());
+        $this->assertEquals('', $this->group->getRepositoryId());
+        $this->assertNull($this->group->getValidRepository());
+        $this->assertEquals('', $this->group->getstr_repository());
+    }
+
+    public function testProfReturnsShiftProfessor()
+    {
+        $prof = new \User('prof', 'Professor User', 'prof@example.com', '', ROLE_PROF, false);
+        $this->group->shift->prof = $prof;
+
+        $this->assertSame($prof, $this->group->prof());
+    }
+
+    public function testToStringReturnsGroupNumber()
+    {
+        $this->assertEquals('1', (string)$this->group);
+    }
+
+    public function testSetRepositoryStoresParsedRepository()
+    {
+        $oldEntityManager = $this->mockGroupsByRepo([]);
+        $this->mockGitHubClient();
+
+        try {
+            $this->group->set_repository('https://github.com/mockorg/mockrepo');
+            $this->assertEquals('github:mockorg/mockrepo', $this->group->repository);
+        } finally {
+            $GLOBALS['entityManager'] = $oldEntityManager;
+        }
+    }
+
+    public function testSetRepositoryCanClearRepository()
+    {
+        $this->group->repository = 'github:mockorg/mockrepo';
+
+        $this->group->set_repository('');
+
+        $this->assertEquals('', $this->group->repository);
+    }
+
+    public function testSetRepositoryDoesNotCheckLimitWhenRepositoryUnchanged()
+    {
+        $this->group->repository = 'github:mockorg/mockrepo';
+        $oldEntityManager = $this->mockGroupsByRepo(array_fill(0, 5, ['id' => 1]));
+        $this->mockGitHubClient();
+
+        try {
+            $this->group->set_repository('https://github.com/mockorg/mockrepo');
+            $this->assertEquals('github:mockorg/mockrepo', $this->group->repository);
+        } finally {
+            $GLOBALS['entityManager'] = $oldEntityManager;
+        }
+    }
+
+    public function testSetRepositoryThrowsWhenRepositoryAlreadyHasFiveGroups()
+    {
+        $oldEntityManager = $this->mockGroupsByRepo(array_fill(0, 5, ['id' => 1]));
+        $this->mockGitHubClient();
+
+        try {
+            $this->expectException(\ValidationException::class);
+            $this->expectExceptionMessage('Exceed the maximum number of groups per repository');
+            $this->group->set_repository('https://github.com/mockorg/mockrepo');
+        } finally {
+            $GLOBALS['entityManager'] = $oldEntityManager;
+        }
+    }
+
+    public function testUrlSettersStoreValidUrls()
+    {
+        foreach ($this->urlSetterCases() as $setter => $property) {
+            $url = "https://example.org/$property";
+
+            $this->group->$setter($url);
+
+            $this->assertEquals($url, $this->group->$property);
+        }
+    }
+
+    public function testUrlSettersCanClearUrls()
+    {
+        foreach ($this->urlSetterCases() as $setter => $property) {
+            $this->group->$property = "https://example.org/$property";
+
+            $this->group->$setter('');
+
+            $this->assertEquals('', $this->group->$property);
+        }
+    }
+
+    public function testUrlSettersRejectMalformedUrls()
+    {
+        foreach ($this->urlSetterCases() as $setter => $property) {
+            $previous = $this->group->$property;
+
+            try {
+                $this->group->$setter('not-a-url');
+                $this->fail("$setter should reject malformed URLs");
+            } catch (\ValidationException $exception) {
+                $this->assertEquals('Malformed URL', $exception->getMessage());
+                $this->assertEquals($previous, $this->group->$property);
+            }
+        }
+    }
+
+    private function urlSetterCases(): array
+    {
+        return [
+            'set_project_website' => 'project_website',
+            'set_coding_style' => 'coding_style',
+            'set_bugs_for_beginners' => 'bugs_for_beginners',
+            'set_project_ideas' => 'project_ideas',
+            'set_getting_started_manual' => 'getting_started_manual',
+            'set_developers_manual' => 'developers_manual',
+            'set_testing_manual' => 'testing_manual',
+            'set_developers_mailing_list' => 'developers_mailing_list',
+            'set_patch_submission' => 'patch_submission',
+        ];
+    }
+
+    private function mockGitHubClient(): void
+    {
+        $this->replaceCachedGitHubClient(new class {
+            public function api($endpoint) {
+                return new class {
+                    public function show($owner, $repo) {
+                        return [
+                            'full_name' => "$owner/$repo",
+                            'default_branch' => 'main',
+                        ];
+                    }
+                };
+            }
+        });
+    }
+
+    private function mockGroupsByRepo(array $groups): mixed
+    {
+        $oldEntityManager = $GLOBALS['entityManager'] ?? null;
+        $GLOBALS['entityManager'] = new FakeQueryResultEntityManager($groups);
+        return $oldEntityManager;
+    }
+}

--- a/tests/Unit/PullRequestTest.php
+++ b/tests/Unit/PullRequestTest.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\Unit\Base\UnitTestCase;
+
+
+
+/**
+ * Test suite for PullRequest entity
+ * 
+ * Tests pull request abstract class structure
+ */
+class PullRequestTest extends UnitTestCase
+{
+    /**
+     * Test pull request is abstract
+     */
+    public function testPullRequestIsAbstract()
+    {
+        $reflection = new \ReflectionClass(\PullRequest::class);
+        $this->assertTrue($reflection->isAbstract());
+    }
+
+    /**
+     * Test pull request has repository property
+     */
+    public function testPullRequestHasRepositoryProperty()
+    {
+        $reflection = new \ReflectionClass(\PullRequest::class);
+        $this->assertTrue($reflection->hasProperty('repository'));
+    }
+
+    /**
+     * Test pull request has required abstract methods
+     */
+    public function testPullRequestHasRequiredAbstractMethods()
+    {
+        $reflection = new \ReflectionClass(\PullRequest::class);
+        $methods = $reflection->getMethods(\ReflectionMethod::IS_ABSTRACT);
+        
+        $methodNames = array_map(fn($m) => $m->getName(), $methods);
+        
+        $this->assertContains('url', $methodNames);
+        $this->assertContains('branchURL', $methodNames);
+        $this->assertContains('origin', $methodNames);
+        $this->assertContains('isClosed', $methodNames);
+        $this->assertContains('wasMerged', $methodNames);
+        $this->assertContains('mergedBy', $methodNames);
+        $this->assertContains('mergeDate', $methodNames);
+        $this->assertContains('linesAdded', $methodNames);
+        $this->assertContains('linesDeleted', $methodNames);
+        $this->assertContains('filesModified', $methodNames);
+        $this->assertContains('failedCIjobs', $methodNames);
+    }
+
+    /**
+     * Test pull request can be extended
+     */
+    public function testPullRequestCanBeExtended()
+    {
+        // Create anonymous implementation of abstract class for testing
+        $prImplementation = new class extends \PullRequest {
+            public function url(): string {
+                return 'https://github.com/example/repo/pull/123';
+            }
+            
+            public function branchURL(): string {
+                return 'https://github.com/example/repo/tree/feature-branch';
+            }
+            
+            public function origin(): string {
+                return 'github';
+            }
+            
+            public function isClosed(): bool {
+                return false;
+            }
+            
+            public function wasMerged(): bool {
+                return false;
+            }
+            
+            public function mergedBy(): string {
+                return '';
+            }
+            
+            public function mergeDate(): \DateTimeImmutable {
+                return new \DateTimeImmutable();
+            }
+            
+            public function linesAdded(): int {
+                return 100;
+            }
+            
+            public function linesDeleted(): int {
+                return 50;
+            }
+            
+            public function filesModified(): int {
+                return 5;
+            }
+            
+            public function failedCIjobs(string $hash): array {
+                return [];
+            }
+            
+            public function __toString() {
+                return '#123';
+            }
+        };
+        
+        $this->assertInstanceOf(\PullRequest::class, $prImplementation);
+        $this->assertEquals('https://github.com/example/repo/pull/123', $prImplementation->url());
+        $this->assertEquals('github', $prImplementation->origin());
+        $this->assertFalse($prImplementation->isClosed());
+    }
+}

--- a/tests/Unit/RepositoryTest.php
+++ b/tests/Unit/RepositoryTest.php
@@ -1,0 +1,327 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\Unit\Base\UnitTestCase;
+
+
+
+/**
+ * Test suite for Repository entity
+ * 
+ * Tests repository parsing and property extraction
+ */
+class RepositoryTest extends UnitTestCase
+{
+    /**
+     * Test that repository can be created with valid ID
+     */
+    public function testRepositoryCanBeCreated()
+    {
+        $repo = new \Repository('github:owner/repo-name');
+        
+        $this->assertInstanceOf(\Repository::class, $repo);
+        $this->assertEquals('github:owner/repo-name', $repo->id);
+    }
+
+    /**
+     * Test that name() method extracts repository name
+     */
+    public function testNameExtractsRepositoryName()
+    {
+        $repo = new \Repository('github:owner/repo-name');
+        
+        $this->assertEquals('owner/repo-name', $repo->name());
+    }
+
+    /**
+     * Test name() with different repository names
+     */
+    public function testNameWithDifferentRepositories()
+    {
+        $testCases = [
+            'github:laravel/framework' => 'laravel/framework',
+            'github:facebook/react' => 'facebook/react',
+            'github:torvalds/linux' => 'torvalds/linux',
+        ];
+
+        foreach ($testCases as $id => $expectedName) {
+            $repo = new \Repository($id);
+            $this->assertEquals($expectedName, $repo->name());
+        }
+    }
+
+    /**
+     * Test that platform() method extracts platform
+     */
+    public function testPlatformReturnsPlatform()
+    {
+        $repo = new \Repository('github:owner/repo');
+        
+        $this->assertEquals('github', $repo->platform());
+    }
+
+    /**
+     * Test platform() with various platforms
+     */
+    public function testPlatformWithVariousPlatforms()
+    {
+        $platforms = ['github', 'gitrepo', 'custom'];
+
+        foreach ($platforms as $platform) {
+            $repo = new \Repository("$platform:owner/name");
+            $this->assertEquals($platform, $repo->platform());
+        }
+    }
+
+    /**
+     * Test __toString() method
+     */
+    public function testToStringReturnsStringRepresentation()
+    {
+        // This test assumes __toString returns get('toString')
+        // which would depend on platform implementation
+        $repo = new \Repository('github:owner/repo-name');
+        
+        // Just verify it can be converted to string
+        $this->assertIsString((string)$repo);
+    }
+
+    /**
+     * Test repository ID with hyphenated names
+     */
+    public function testRepositoryNameWithHyphens()
+    {
+        $repo = new \Repository('github:some-org/some-repo-name');
+        
+        $this->assertEquals('some-org/some-repo-name', $repo->name());
+        $this->assertEquals('github', $repo->platform());
+    }
+
+    /**
+     * Test repository ID with underscores
+     */
+    public function testRepositoryNameWithUnderscores()
+    {
+        $repo = new \Repository('github:_owner/_repo_name');
+        
+        $this->assertEquals('_owner/_repo_name', $repo->name());
+    }
+
+    /**
+     * Test repository name with numbers
+     */
+    public function testRepositoryNameWithNumbers()
+    {
+        $repo = new \Repository('github:owner123/repo456');
+        
+        $this->assertEquals('owner123/repo456', $repo->name());
+        $this->assertEquals('github', $repo->platform());
+    }
+
+    /**
+     * Test that different repositories are different instances
+     */
+    public function testDifferentRepositoriesAreDifferentInstances()
+    {
+        $repo1 = new \Repository('github:owner1/repo1');
+        $repo2 = new \Repository('github:owner2/repo2');
+        
+        $this->assertNotSame($repo1, $repo2);
+        $this->assertNotEquals($repo1->id, $repo2->id);
+    }
+
+    /**
+     * Test repository platform delimiter is colon
+     */
+    public function testPlatformNameDelimiterIsColon()
+    {
+        $repo = new \Repository('github:owner/repo');
+        
+        // Verify the delimiter works correctly
+        $this->assertStringContainsString(':', $repo->id);
+        
+        $parts = explode(':', $repo->id);
+        $this->assertEquals('github', $parts[0]);
+        $this->assertEquals('owner/repo', $parts[1]);
+    }
+
+    /**
+     * Test name with slashes (owner/repo structure)
+     */
+    public function testNamePreservesSlashes()
+    {
+        $repo = new \Repository('github:owner/repo');
+        $name = $repo->name();
+        
+        $this->assertStringContainsString('/', $name);
+        
+        $parts = explode('/', $name);
+        $this->assertCount(2, $parts);
+    }
+
+    /**
+     * Test repository ID is stored unchanged
+     */
+    public function testRepositoryIdIsStoredUnchanged()
+    {
+        $id = 'github:some-owner/some-repo-name';
+        $repo = new \Repository($id);
+        
+        $this->assertEquals($id, $repo->id);
+    }
+
+    /**
+     * Test name extraction with complex repository names
+     */
+    public function testNameExtractWithComplexNames()
+    {
+        $repo = new \Repository('github:microsoft/vscode-python');
+        
+        $platform = $repo->platform();
+        $name = $repo->name();
+        
+        $this->assertEquals('github', $platform);
+        $this->assertEquals('microsoft/vscode-python', $name);
+        $this->assertStringStartsWith('microsoft', $name);
+    }
+
+    public function testGithubBackedRepositoryMethods()
+    {
+        $this->mockCachedGitHubClient();
+        $repo = new \Repository('github:owner/repo');
+
+        $this->assertEquals('1', $repo->isValid());
+        $this->assertEquals('main', $repo->defaultBranch());
+        $this->assertEquals('upstream/repo', $repo->parent());
+        $this->assertEquals('PHP', $repo->language());
+        $this->assertEquals('MIT', $repo->license());
+        $this->assertEquals(1234, $repo->stars());
+        $this->assertEquals(['php', 'testing'], $repo->topics());
+        $this->assertEquals(150, $repo->linesOfCode());
+        $this->assertEquals(10, $repo->commitsLastMonth());
+        $this->assertEquals('https://github.com/owner/repo', (string)$repo);
+    }
+
+    public function testFactoryCreatesGithubRepositoryId()
+    {
+        $this->mockCachedGitHubClient();
+
+        $this->assertEquals(
+            'github:owner/repo',
+            \Repository::factory('https://github.com/owner/repo')
+        );
+    }
+
+    public function testFactoryRejectsUnsupportedUrl()
+    {
+        $this->expectException(\ValidationException::class);
+        $this->expectExceptionMessage('Unsupported URL');
+
+        \Repository::factory('https://gitlab.com/owner/repo');
+    }
+
+    public function testFactoryRejectsUnknownRepository()
+    {
+        $this->mockCachedGitHubClient(throwOnShow: true);
+
+        $this->expectException(\ValidationException::class);
+        $this->expectExceptionMessage('Unknown project repository');
+        \Repository::factory('https://github.com/owner/missing');
+    }
+
+    public function testGithubBackedRepositoryMethodsHandleMissingOptionalData()
+    {
+        $this->mockCachedGitHubClient(parent: null, license: null, language: null);
+        $repo = new \Repository('github:owner/repo');
+
+        $this->assertNull($repo->parent());
+        $this->assertEquals('', $repo->language());
+        $this->assertNull($repo->license());
+    }
+
+    public function testIsValidReturnsFalseForGitHubNotFound()
+    {
+        $this->replaceCachedGitHubClient(new class {
+            public function api($endpoint) {
+                return new class {
+                    public function show($owner, $repo) {
+                        throw new \Github\Exception\RuntimeException('Not Found');
+                    }
+                };
+            }
+        });
+        $repo = new \Repository('github:owner/missing');
+
+        $this->assertFalse((bool)$repo->isValid());
+    }
+
+    public function testUnsupportedRepositoryPlatformTriggersAssertion()
+    {
+        $repo = new \Repository('gitlab:owner/repo');
+
+        $this->expectException(\AssertionError::class);
+
+        $repo->isValid();
+    }
+
+    private function mockCachedGitHubClient(
+        bool $throwOnShow = false,
+        ?string $parent = 'upstream/repo',
+        ?string $license = 'MIT',
+        ?string $language = 'PHP'
+    ): void {
+        $this->replaceCachedGitHubClient(new class($throwOnShow, $parent, $license, $language) {
+            public function __construct(
+                private bool $throwOnShow,
+                private ?string $parent,
+                private ?string $license,
+                private ?string $language
+            ) {}
+
+            public function api($endpoint) {
+                return new class($this->throwOnShow, $this->parent, $this->license, $this->language) {
+                    public function __construct(
+                        private bool $throwOnShow,
+                        private ?string $parent,
+                        private ?string $license,
+                        private ?string $language
+                    ) {}
+
+                    public function show($owner, $repo) {
+                        if ($this->throwOnShow) {
+                            throw new \Exception('missing');
+                        }
+
+                        return [
+                            'full_name' => "$owner/$repo",
+                            'default_branch' => 'main',
+                            'parent' => $this->parent === null
+                                ? null
+                                : ['full_name' => $this->parent],
+                            'language' => $this->language,
+                            'license' => $this->license === null
+                                ? null
+                                : ['name' => $this->license],
+                            'stargazers_count' => 1234,
+                            'topics' => ['php', 'testing'],
+                        ];
+                    }
+
+                    public function languages($owner, $repo) {
+                        return [
+                            'PHP' => 4000,
+                            'JavaScript' => 2000,
+                        ];
+                    }
+
+                    public function participation($owner, $repo) {
+                        return [
+                            'all' => array_merge(array_fill(0, 48, 0), [1, 2, 3, 4]),
+                        ];
+                    }
+                };
+            }
+        });
+    }
+}

--- a/tests/Unit/RepositoryUserTest.php
+++ b/tests/Unit/RepositoryUserTest.php
@@ -1,0 +1,333 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\Unit\Base\UnitTestCase;
+
+
+
+require_once dirname(__DIR__, 2) . '/entities/RepositoryUser.php';
+
+/**
+ * Test suite for RepositoryUser entity
+ * 
+ * Tests repository user creation, parsing, and validation
+ */
+class RepositoryUserTest extends UnitTestCase
+{
+    private \User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = new \User(
+            username: 'student1',
+            name: 'John Student',
+            email: 'john@example.com',
+            photo: '',
+            role: ROLE_STUDENT,
+            dummy: false
+        );
+    }
+
+    /**
+     * Test repository user can be created with User object
+     */
+    public function testRepositoryUserCanBeCreated()
+    {
+        $this->user->repository_user = 'github:johnsmith';
+        $repoUser = new \RepositoryUser($this->user);
+        
+        $this->assertInstanceOf(\RepositoryUser::class, $repoUser);
+        $this->assertEquals($this->user, $repoUser->user);
+    }
+
+    /**
+     * Test id method returns repository user ID
+     */
+    public function testIdMethodReturnsRepositoryUserId()
+    {
+        $this->user->repository_user = 'github:johnsmith';
+        $repoUser = new \RepositoryUser($this->user);
+        
+        $this->assertEquals('github:johnsmith', $repoUser->id());
+    }
+
+    /**
+     * Test username method extracts username from ID
+     */
+    public function testUsernameMethodExtractsUsername()
+    {
+        $this->user->repository_user = 'github:johnsmith';
+        $repoUser = new \RepositoryUser($this->user);
+        
+        $this->assertEquals('johnsmith', $repoUser->username());
+    }
+
+    /**
+     * Test username with different platform
+     */
+    public function testUsernameWithDifferentPlatform()
+    {
+        $this->user->repository_user = 'gitlab:jane.doe';
+        $repoUser = new \RepositoryUser($this->user);
+        
+        $this->assertEquals('jane.doe', $repoUser->username());
+    }
+
+    /**
+     * Test parse method with GitHub URL
+     */
+    public function testParseMethodWithGitHubUrl()
+    {
+        $url = 'https://github.com/johnsmith';
+        $result = \RepositoryUser::parse($url);
+        
+        $this->assertStringContainsString('github', $result);
+        $this->assertStringContainsString('johnsmith', $result);
+    }
+
+    /**
+     * Test parse method with plain username
+     */
+    public function testParseMethodWithPlainUsername()
+    {
+        $username = 'github:johnsmith';
+        $result = \RepositoryUser::parse($username);
+        
+        $this->assertEquals('github:johnsmith', $result);
+    }
+
+    /**
+     * Test parse method preserves already canonical input
+     */
+    public function testParseMethodWithValidFormat()
+    {
+        // Test that parse accepts valid format
+        $result = \RepositoryUser::parse('github:johnsmith');
+        $this->assertEquals('github:johnsmith', $result);
+    }
+
+    /**
+     * Test parse leaves non-URL input for check() to validate
+     */
+    public function testParseLeavesNonUrlInputForValidation()
+    {
+        $result = \RepositoryUser::parse('invalidformat');
+        $this->assertEquals('invalidformat', $result);
+    }
+
+    /**
+     * Test repository user with different platforms
+     */
+    public function testRepositoryUserWithDifferentPlatforms()
+    {
+        $platforms = [
+            'github:user1',
+            'gitlab:user2',
+            'bitbucket:user3',
+        ];
+        
+        foreach ($platforms as $repoId) {
+            $user = new \User('student', 'Name', 'email@example.com', '', ROLE_STUDENT, false);
+            $user->repository_user = $repoId;
+            $repoUser = new \RepositoryUser($user);
+            
+            $this->assertEquals($repoId, $repoUser->id());
+        }
+    }
+
+    /**
+     * Test username with special characters
+     */
+    public function testUsernameWithSpecialCharacters()
+    {
+        $this->user->repository_user = 'github:user-name_123';
+        $repoUser = new \RepositoryUser($this->user);
+        
+        $this->assertEquals('user-name_123', $repoUser->username());
+    }
+
+    /**
+     * Test multiple repository users from same user
+     */
+    public function testMultipleRepositoryUsersFromSameUser()
+    {
+        $user1 = new \User('student', 'Name', 'email@example.com', '', ROLE_STUDENT, false);
+        $user1->repository_user = 'github:johnsmith';
+        $repoUser1 = new \RepositoryUser($user1);
+        
+        // Create new user with different repository
+        $user2 = new \User('student2', 'Name2', 'email2@example.com', '', ROLE_STUDENT, false);
+        $user2->repository_user = 'github:jane.doe';
+        $repoUser2 = new \RepositoryUser($user2);
+        
+        $this->assertEquals('johnsmith', $repoUser1->username());
+        $this->assertEquals('jane.doe', $repoUser2->username());
+    }
+
+    /**
+     * Test repository user equality
+     */
+    public function testRepositoryUserEquality()
+    {
+        $this->user->repository_user = 'github:johnsmith';
+        $repoUser1 = new \RepositoryUser($this->user);
+        $repoUser2 = new \RepositoryUser($this->user);
+        
+        $this->assertEquals($repoUser1->id(), $repoUser2->id());
+        $this->assertEquals($repoUser1->username(), $repoUser2->username());
+    }
+
+    public function testPROpenedEventStoresPullRequestAndDate()
+    {
+        $pr = new class extends \PullRequest {
+            public function url(): string { return 'https://github.com/mockorg/mockrepo/pull/1'; }
+            public function branchURL(): string { return 'https://github.com/mockorg/mockrepo/tree/branch'; }
+            public function origin(): string { return 'mockorg:mockrepo:branch'; }
+            public function isClosed(): bool { return false; }
+            public function wasMerged(): bool { return false; }
+            public function mergedBy(): string { return ''; }
+            public function mergeDate(): \DateTimeImmutable { return new \DateTimeImmutable(); }
+            public function linesAdded(): int { return 0; }
+            public function linesDeleted(): int { return 0; }
+            public function filesModified(): int { return 0; }
+            public function failedCIjobs(string $hash): array { return []; }
+            public function __toString(): string { return $this->url(); }
+        };
+        $date = new \DateTimeImmutable('2026-04-26 10:00:00');
+
+        $event = new \PROpenedEvent($pr, $date);
+
+        $this->assertSame($pr, $event->pr);
+        $this->assertSame($date, $event->date);
+    }
+
+    public function testParseThrowsForUnsupportedUrl()
+    {
+        $this->expectException(\ValidationException::class);
+        $this->expectExceptionMessage('Unsupported URL');
+
+        \RepositoryUser::parse('https://gitlab.com/johnsmith');
+    }
+
+    public function testCheckAcceptsExistingGithubUser()
+    {
+        $this->user->repository_user = 'github:johnsmith';
+
+        \RepositoryUser::check($this->user);
+
+        $this->assertEquals('github:johnsmith', $this->user->repository_user);
+    }
+
+    public function testCheckThrowsWhenUserDoesNotExist()
+    {
+        $this->mockMissingGitHubUser();
+        $this->user->repository_user = 'github:missinguser';
+
+        $this->expectException(\ValidationException::class);
+        $this->expectExceptionMessage('user does not exist');
+        \RepositoryUser::check($this->user);
+    }
+
+    public function testPlatformMethodExtractsPlatform()
+    {
+        $this->user->repository_user = 'github:johnsmith';
+        $repoUser = new \RepositoryUser($this->user);
+
+        $this->assertEquals('github', $repoUser->platform());
+    }
+
+    public function testGithubBackedProfileMethods()
+    {
+        $this->user->repository_user = 'github:johnsmith';
+        $repoUser = new \RepositoryUser($this->user);
+
+        $this->assertTrue($repoUser->isValid());
+        $this->assertEquals('https://github.com/johnsmith', $repoUser->profileURL());
+        $this->assertEquals('Johnsmith User', $repoUser->name());
+        $this->assertEquals('johnsmith@example.com', $repoUser->email());
+        $this->assertEquals('Tech Company', $repoUser->company());
+        $this->assertEquals('Lisbon, Portugal', $repoUser->location());
+    }
+
+    public function testUnsupportedRepositoryUserPlatformTriggersAssertion()
+    {
+        $this->user->repository_user = 'gitlab:johnsmith';
+        $repoUser = new \RepositoryUser($this->user);
+
+        $this->expectException(\AssertionError::class);
+
+        $repoUser->isValid();
+    }
+
+    public function testDescriptionIncludesAvailableProfileFields()
+    {
+        $this->user->repository_user = 'github:johnsmith';
+        $repoUser = new \RepositoryUser($this->user);
+
+        $description = $repoUser->description();
+
+        $this->assertStringContainsString('[name: Johnsmith User]', $description);
+        $this->assertStringContainsString('[email: johnsmith@example.com]', $description);
+        $this->assertStringContainsString('[company: Tech Company]', $description);
+        $this->assertStringContainsString('[location: Lisbon, Portugal]', $description);
+    }
+
+    public function testDescriptionSkipsMissingProfileFields()
+    {
+        $this->replaceGitHubClient(new class {
+            public function api($endpoint) {
+                return new class {
+                    public function show($username) {
+                        return [
+                            'login' => $username,
+                            'name' => 'Only Name',
+                            'email' => null,
+                            'company' => '',
+                            'location' => null,
+                        ];
+                    }
+                };
+            }
+        });
+        $this->user->repository_user = 'github:johnsmith';
+        $repoUser = new \RepositoryUser($this->user);
+
+        $this->assertEquals(' [name: Only Name]', $repoUser->description());
+    }
+
+    public function testGetUnprocessedEventsReturnsArrayWhenGitHubErrors()
+    {
+        if (!function_exists('\\GitHub\\github_set_etag')) {
+            eval('namespace GitHub; function github_set_etag($etag) {} function github_remove_etag() {}');
+        }
+        $this->mockRuntimeExceptionGitHubClient();
+        $this->user->repository_user = 'github:johnsmith';
+        $repoUser = new \RepositoryUser($this->user);
+
+        $this->assertEquals([], $repoUser->getUnprocessedEvents());
+    }
+
+    private function mockMissingGitHubUser(): void
+    {
+        $this->replaceGitHubClient(new class {
+            public function api($endpoint) {
+                return new class {
+                    public function show($username) {
+                        throw new \Exception('not found');
+                    }
+                };
+            }
+        });
+    }
+
+    private function mockRuntimeExceptionGitHubClient(): void
+    {
+        $this->replaceGitHubClient(new class {
+            public function user($type) {
+                throw new \Github\Exception\RuntimeException('Not Found');
+            }
+        });
+    }
+}

--- a/tests/Unit/SelectedBugTest.php
+++ b/tests/Unit/SelectedBugTest.php
@@ -1,0 +1,323 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\Unit\Base\UnitTestCase;
+use Tests\Mocks\FakeQueryResultEntityManager;
+use ValidationException;
+
+/**
+ * Test suite for SelectedBug entity
+ * 
+ * Tests selected bug creation, properties, and structure
+ */
+class SelectedBugTest extends UnitTestCase
+{
+    private \User $testUser;
+    private \ProjGroup $testGroup;
+    private \Shift $testShift;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Create test shift
+        $this->testShift = new \Shift('T01', 2024);
+
+        // Create test group
+        $this->testGroup = new \ProjGroup(1, 2024, $this->testShift);
+
+        // Create test user
+        $this->testUser = new \User(
+            username: 'bugfinder',
+            name: 'Bug Finder',
+            email: 'bug@example.com',
+            photo: '',
+            role: ROLE_STUDENT,
+            dummy: false
+        );
+    }
+
+    /**
+     * Test selected bug can be instantiated
+     */
+    public function testSelectedBugCanBeInstantiated()
+    {
+        $bug = new \SelectedBug();
+        $this->assertInstanceOf(\SelectedBug::class, $bug);
+    }
+
+    /**
+     * Test selected bug has year property
+     */
+    public function testSelectedBugHasYearProperty()
+    {
+        $bug = new \SelectedBug();
+        $bug->year = 2024;
+        $this->assertEquals(2024, $bug->year);
+    }
+
+    /**
+     * Test selected bug has issue_url property
+     */
+    public function testSelectedBugHasIssueUrlProperty()
+    {
+        $bug = new \SelectedBug();
+        $bug->issue_url = 'https://github.com/owner/repo/issues/1';
+        $this->assertEquals('https://github.com/owner/repo/issues/1', $bug->issue_url);
+    }
+
+    /**
+     * Test selected bug has repro_url property
+     */
+    public function testSelectedBugHasReproUrlProperty()
+    {
+        $bug = new \SelectedBug();
+        $bug->repro_url = 'https://youtube.com/watch?v=test';
+        $this->assertEquals('https://youtube.com/watch?v=test', $bug->repro_url);
+    }
+
+    /**
+     * Test selected bug has description property
+     */
+    public function testSelectedBugHasDescriptionProperty()
+    {
+        $bug = new \SelectedBug();
+        $bug->description = 'Test bug description';
+        $this->assertEquals('Test bug description', $bug->description);
+    }
+
+    /**
+     * Test selected bug has user property
+     */
+    public function testSelectedBugHasUserProperty()
+    {
+        $bug = new \SelectedBug();
+        $bug->user = $this->testUser;
+        $this->assertEquals($this->testUser, $bug->user);
+    }
+
+    /**
+     * Test set_issue_url requires non-empty URL
+     */
+    public function testSetIssueUrlRequiresNonEmptyUrl()
+    {
+        $bug = new \SelectedBug();
+        $bug->year = 2024;
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('Issue URL is required');
+
+        $bug->set_issue_url('');
+    }
+
+    /**
+     * Test set_repro_url accepts empty URL
+     */
+    public function testSetReproUrlAcceptsEmptyUrl()
+    {
+        $bug = new \SelectedBug();
+        
+        // Empty URL should not trigger video validation
+        $bug->set_repro_url('');
+        $this->assertEquals('', $bug->repro_url);
+    }
+
+    public function testSetReproUrlRejectsUnrecognizedVideoUrl()
+    {
+        $bug = new \SelectedBug();
+
+        $this->expectException(ValidationException::class);
+
+        $bug->set_repro_url('https://example.invalid/not-a-video');
+    }
+
+    /**
+     * Test issue_url defaults to empty string
+     */
+    public function testIssueUrlDefaultsToEmpty()
+    {
+        $bug = new \SelectedBug();
+        $this->assertEquals('', $bug->issue_url);
+    }
+
+    /**
+     * Test repro_url defaults to empty string
+     */
+    public function testReproUrlDefaultsToEmpty()
+    {
+        $bug = new \SelectedBug();
+        $this->assertEquals('', $bug->repro_url);
+    }
+
+    /**
+     * Test description defaults to empty string
+     */
+    public function testDescriptionDefaultsToEmpty()
+    {
+        $bug = new \SelectedBug();
+        $this->assertEquals('', $bug->description);
+    }
+
+    /**
+     * Test multiple bugs can have different years
+     */
+    public function testMultipleBugsDifferentYears()
+    {
+        $bug1 = new \SelectedBug();
+        $bug1->year = 2024;
+        
+        $bug2 = new \SelectedBug();
+        $bug2->year = 2025;
+        
+        $this->assertNotEquals($bug1->year, $bug2->year);
+    }
+
+    /**
+     * Test bug can have different URLs set
+     */
+    public function testBugCanHaveDifferentUrls()
+    {
+        $bug = new \SelectedBug();
+        
+        $bug->issue_url = 'https://github.com/owner/repo/issues/1';
+        $this->assertEquals('https://github.com/owner/repo/issues/1', $bug->issue_url);
+        
+        $bug->issue_url = 'https://github.com/owner/repo/issues/2';
+        $this->assertEquals('https://github.com/owner/repo/issues/2', $bug->issue_url);
+    }
+
+    /**
+     * Test description can be updated
+     */
+    public function testDescriptionCanBeUpdated()
+    {
+        $bug = new \SelectedBug();
+        
+        $bug->description = 'First description';
+        $this->assertEquals('First description', $bug->description);
+        
+        $bug->description = 'Updated description';
+        $this->assertEquals('Updated description', $bug->description);
+    }
+
+    /**
+     * Test bug user relationship
+     */
+    public function testBugUserRelationship()
+    {
+        $bug1 = new \SelectedBug();
+        $bug1->user = $this->testUser;
+        
+        $user2 = new \User(
+            username: 'user2',
+            name: 'User Two',
+            email: 'user2@example.com',
+            photo: '',
+            role: ROLE_STUDENT,
+            dummy: false
+        );
+        $bug2 = new \SelectedBug();
+        $bug2->user = $user2;
+        
+        $this->assertNotEquals($bug1->user, $bug2->user);
+    }
+
+    public function testFactoryCreatesSelectedBugWithValidData()
+    {
+        $oldEntityManager = $this->mockExistingBug(null);
+
+        try {
+            $bug = \SelectedBug::factory(
+                $this->testGroup,
+                $this->testUser,
+                '  Detailed bug description  ',
+                'https://github.com/owner/repo/issues/123',
+                ''
+            );
+
+            $this->assertEquals(2024, $bug->year);
+            $this->assertSame($this->testUser, $bug->user);
+            $this->assertEquals('Detailed bug description', $bug->description);
+            $this->assertEquals('https://github.com/owner/repo/issues/123', $bug->issue_url);
+            $this->assertEquals('', $bug->repro_url);
+        } finally {
+            $GLOBALS['entityManager'] = $oldEntityManager;
+        }
+    }
+
+    public function testSetIssueUrlStoresValidUrl()
+    {
+        $oldEntityManager = $this->mockExistingBug(null);
+        $bug = new \SelectedBug();
+        $bug->year = 2024;
+
+        try {
+            $bug->set_issue_url('https://github.com/owner/repo/issues/123');
+            $this->assertEquals('https://github.com/owner/repo/issues/123', $bug->issue_url);
+        } finally {
+            $GLOBALS['entityManager'] = $oldEntityManager;
+        }
+    }
+
+    public function testSetIssueUrlThrowsWhenBugAlreadySelected()
+    {
+        $existingBug = new \SelectedBug();
+        $existingBug->year = 2024;
+        $existingBug->issue_url = 'https://github.com/owner/repo/issues/123';
+        $oldEntityManager = $this->mockExistingBug($existingBug);
+
+        $bug = new \SelectedBug();
+        $bug->year = 2024;
+
+        try {
+            $this->expectException(ValidationException::class);
+            $this->expectExceptionMessage('This bug has been selected by another student already');
+            $bug->set_issue_url('https://github.com/owner/repo/issues/123');
+        } finally {
+            $GLOBALS['entityManager'] = $oldEntityManager;
+        }
+    }
+
+    public function testSetIssueUrlSkipsDuplicateCheckForUnchangedUrl()
+    {
+        $existingBug = new \SelectedBug();
+        $existingBug->year = 2024;
+        $existingBug->issue_url = 'https://github.com/owner/repo/issues/123';
+        $oldEntityManager = $this->mockExistingBug($existingBug);
+
+        $bug = new \SelectedBug();
+        $bug->year = 2024;
+        $bug->issue_url = 'https://github.com/owner/repo/issues/123';
+
+        try {
+            $bug->set_issue_url('https://github.com/owner/repo/issues/123');
+            $this->assertEquals('https://github.com/owner/repo/issues/123', $bug->issue_url);
+        } finally {
+            $GLOBALS['entityManager'] = $oldEntityManager;
+        }
+    }
+
+    public function testSetIssueUrlRejectsMalformedUrl()
+    {
+        $oldEntityManager = $this->mockExistingBug(null);
+        $bug = new \SelectedBug();
+        $bug->year = 2024;
+
+        try {
+            $this->expectException(ValidationException::class);
+            $this->expectExceptionMessage('Malformed URL');
+            $bug->set_issue_url('not-a-url');
+        } finally {
+            $GLOBALS['entityManager'] = $oldEntityManager;
+        }
+    }
+
+    private function mockExistingBug(?\SelectedBug $existingBug): mixed
+    {
+        $oldEntityManager = $GLOBALS['entityManager'] ?? null;
+        $GLOBALS['entityManager'] = new FakeQueryResultEntityManager($existingBug);
+
+        return $oldEntityManager;
+    }
+}

--- a/tests/Unit/SessionTest.php
+++ b/tests/Unit/SessionTest.php
@@ -1,0 +1,209 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\Unit\Base\UnitTestCase;
+
+
+
+/**
+ * Test suite for Session entity
+ * 
+ * Tests session creation, expiration, and validation logic
+ */
+class SessionTest extends UnitTestCase
+{
+    private \User $testUser;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Create a test user for session
+        $this->testUser = new \User(
+            username: 'testuser',
+            name: 'Test User',
+            email: 'test@example.com',
+            photo: '',
+            role: ROLE_STUDENT,
+            dummy: false
+        );
+    }
+
+    /**
+     * Test that session can be created with a user
+     */
+    public function testSessionCanBeCreatedWithUser()
+    {
+        $session = new \Session($this->testUser);
+        
+        $this->assertInstanceOf(\Session::class, $session);
+        $this->assertSame($this->testUser, $session->user);
+    }
+
+    /**
+     * Test that session has an ID
+     */
+    public function testSessionHasAnId()
+    {
+        $session = new \Session($this->testUser);
+        
+        $this->assertNotNull($session->id);
+        $this->assertIsString($session->id);
+        $this->assertNotEmpty($session->id);
+    }
+
+    /**
+     * Test that session ID is of expected length (SHA1 substring)
+     */
+    public function testSessionIdIsCorrectLength()
+    {
+        $session = new \Session($this->testUser);
+        
+        // SHA1 produces 40 chars, we take first 32
+        $this->assertEquals(32, strlen($session->id));
+    }
+
+    /**
+     * Test that different sessions have different IDs
+     */
+    public function testDifferentSessionsHaveDifferentIds()
+    {
+        $session1 = new \Session($this->testUser);
+        $session2 = new \Session($this->testUser);
+        
+        $this->assertNotEquals($session1->id, $session2->id);
+    }
+
+    /**
+     * Test that session has an expiration time
+     */
+    public function testSessionHasExpirationTime()
+    {
+        $session = new \Session($this->testUser);
+        
+        $this->assertNotNull($session->expires);
+        $this->assertInstanceOf(\DateTimeImmutable::class, $session->expires);
+    }
+
+    /**
+     * Test that session expires in approximately 90 days
+     */
+    public function testSessionExpiresIn90Days()
+    {
+        $beforeCreation = new \DateTimeImmutable();
+        $session = new \Session($this->testUser);
+        $afterCreation = new \DateTimeImmutable();
+
+        // Add 90 days to current time
+        $expectedExpiration = $beforeCreation->add(new \DateInterval("P90D"));
+        $expectedExpirationAfter = $afterCreation->add(new \DateInterval("P90D"));
+
+        // Session expiration should be between the two times
+        $this->assertGreaterThanOrEqual($expectedExpiration, $session->expires);
+        $this->assertLessThanOrEqual($expectedExpirationAfter, $session->expires);
+    }
+
+    /**
+     * Test that new session is fresh
+     */
+    public function testNewSessionIsFresh()
+    {
+        $session = new \Session($this->testUser);
+        
+        $this->assertTrue($session->isFresh());
+    }
+
+    /**
+     * Test that session user is set correctly
+     */
+    public function testSessionUserIsSetCorrectly()
+    {
+        $session = new \Session($this->testUser);
+        
+        $this->assertEquals('testuser', $session->user->id);
+        $this->assertEquals('Test User', $session->user->name);
+        $this->assertEquals('test@example.com', $session->user->email);
+    }
+
+    /**
+     * Test that session can be created for different users
+     */
+    public function testSessionCanBeCreatedForDifferentUsers()
+    {
+        $user1 = new \User('user1', 'User One', 'user1@example.com', '', ROLE_STUDENT, false);
+        $user2 = new \User('user2', 'User Two', 'user2@example.com', '', ROLE_STUDENT, false);
+
+        $session1 = new \Session($user1);
+        $session2 = new \Session($user2);
+
+        $this->assertEquals('user1', $session1->user->id);
+        $this->assertEquals('user2', $session2->user->id);
+        $this->assertNotEquals($session1->id, $session2->id);
+    }
+
+    /**
+     * Test that session ID consists of valid characters (hex)
+     */
+    public function testSessionIdIsValidHex()
+    {
+        $session = new \Session($this->testUser);
+        
+        // Session ID should be hexadecimal (0-9, a-f)
+        $this->assertMatchesRegularExpression('/^[a-f0-9]{32}$/', $session->id);
+    }
+
+    /**
+     * Test that session expiration is in the future
+     */
+    public function testSessionExpirationIsInFuture()
+    {
+        $session = new \Session($this->testUser);
+        $now = new \DateTimeImmutable();
+        
+        $this->assertGreaterThan($now, $session->expires);
+    }
+
+    /**
+     * Test that multiple sessions from same user have different IDs
+     */
+    public function testMultipleSessionsFromSameUserHaveDifferentIds()
+    {
+        $ids = [];
+        
+        for ($i = 0; $i < 5; $i++) {
+            $session = new \Session($this->testUser);
+            $ids[] = $session->id;
+        }
+
+        // All IDs should be unique
+        $this->assertCount(5, array_unique($ids));
+    }
+
+    /**
+     * Test session ID can be used as string
+     */
+    public function testSessionIdCanBeUsedAsString()
+    {
+        $session = new \Session($this->testUser);
+        
+        $id = $session->id;
+        $this->assertIsString($id);
+        $this->assertTrue(strlen($id) > 0);
+        
+        // Can be used in string context
+        $message = "Session: $id";
+        $this->assertStringContainsString($session->id, $message);
+    }
+
+    /**
+     * Test that session objects are separate instances
+     */
+    public function testSessionObjectsAreSeparateInstances()
+    {
+        $session1 = new \Session($this->testUser);
+        $session2 = new \Session($this->testUser);
+        
+        $this->assertNotSame($session1, $session2);
+    }
+}

--- a/tests/Unit/ShiftTest.php
+++ b/tests/Unit/ShiftTest.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\Unit\Base\UnitTestCase;
+
+
+use Doctrine\Common\Collections\ArrayCollection;
+
+/**
+ * Test suite for Shift entity
+ * 
+ * Tests shift properties, group management, and string representation
+ */
+class ShiftTest extends UnitTestCase
+{
+    private \Shift $shift;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->shift = new \Shift('T01', 2024);
+    }
+
+    /**
+     * Test shift can be instantiated with name and year
+     */
+    public function testShiftCanBeCreated()
+    {
+        $this->assertInstanceOf(\Shift::class, $this->shift);
+        $this->assertEquals('T01', $this->shift->name);
+        $this->assertEquals(2024, $this->shift->year);
+    }
+
+    /**
+     * Test shift has empty groups collection at creation
+     */
+    public function testShiftHasEmptyGroupsCollectionAtCreation()
+    {
+        $this->assertInstanceOf(ArrayCollection::class, $this->shift->groups);
+        $this->assertEquals(0, $this->shift->groups->count());
+    }
+
+    /**
+     * Test shift professor can be set and retrieved
+     */
+    public function testShiftProfessorCanBeSetAndRetrieved()
+    {
+        $professor = new \User('prof1', 'Professor Name', 'prof@example.com', '', ROLE_PROF, false);
+        $this->shift->prof = $professor;
+        
+        $this->assertEquals($professor, $this->shift->prof);
+        $this->assertEquals('prof1', $this->shift->prof->id);
+    }
+
+    /**
+     * Test shift professor can be null
+     */
+    public function testShiftProfessorCanBeNull()
+    {
+        $this->shift->prof = null;
+        
+        $this->assertNull($this->shift->prof);
+    }
+
+    /**
+     * Test shift name can be retrieved
+     */
+    public function testShiftNameCanBeRetrieved()
+    {
+        $this->assertEquals('T01', $this->shift->name);
+        
+        $newShift = new \Shift('T02', 2025);
+        $this->assertEquals('T02', $newShift->name);
+    }
+
+    /**
+     * Test shift year can be retrieved
+     */
+    public function testShiftYearCanBeRetrieved()
+    {
+        $this->assertEquals(2024, $this->shift->year);
+        
+        $newShift = new \Shift('T01', 2025);
+        $this->assertEquals(2025, $newShift->year);
+    }
+
+    /**
+     * Test __toString returns shift name
+     */
+    public function testToStringReturnsShiftName()
+    {
+        $this->assertEquals('T01', (string)$this->shift);
+        
+        $newShift = new \Shift('Turno_A', 2024);
+        $this->assertEquals('Turno_A', (string)$newShift);
+    }
+
+    /**
+     * Test shift name with various formats
+     */
+    public function testShiftNameWithVariousFormats()
+    {
+        $shifts = ['T01', 'T02', 'T03', 'Turno A', 'Practical_1', 'P1-2024'];
+        
+        foreach ($shifts as $name) {
+            $shift = new \Shift($name, 2024);
+            $this->assertEquals($name, $shift->name);
+            $this->assertEquals($name, (string)$shift);
+        }
+    }
+
+    /**
+     * Test multiple shifts can exist independently
+     */
+    public function testMultipleShiftsAreIndependent()
+    {
+        $shift1 = new \Shift('T01', 2024);
+        $shift2 = new \Shift('T02', 2024);
+        
+        $prof1 = new \User('prof1', 'Prof 1', 'prof1@example.com', '', ROLE_PROF, false);
+        $prof2 = new \User('prof2', 'Prof 2', 'prof2@example.com', '', ROLE_PROF, false);
+        
+        $shift1->prof = $prof1;
+        $shift2->prof = $prof2;
+        
+        $this->assertEquals('prof1', $shift1->prof->id);
+        $this->assertEquals('prof2', $shift2->prof->id);
+    }
+
+    /**
+     * Test addGroup method adds group to collection
+     */
+    public function testAddGroupMethodAddsGroupToCollection()
+    {
+        $group = $this->createMock(\ProjGroup::class);
+        
+        $this->shift->addGroup($group);
+        
+        $this->assertEquals(1, $this->shift->groups->count());
+        $this->assertTrue($this->shift->groups->contains($group));
+    }
+
+    /**
+     * Test addGroup can be called multiple times
+     */
+    public function testAddGroupCanBeCalledMultipleTimes()
+    {
+        $group1 = $this->createMock(\ProjGroup::class);
+        $group2 = $this->createMock(\ProjGroup::class);
+        $group3 = $this->createMock(\ProjGroup::class);
+        
+        $this->shift->addGroup($group1);
+        $this->shift->addGroup($group2);
+        $this->shift->addGroup($group3);
+        
+        $this->assertEquals(3, $this->shift->groups->count());
+    }
+}

--- a/tests/Unit/UserTest.php
+++ b/tests/Unit/UserTest.php
@@ -1,0 +1,544 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\Unit\Base\UnitTestCase;
+
+
+
+/**
+ * Test suite for User entity
+ * 
+ * Tests the User class properties, methods, and business logic
+ */
+class UserTest extends UnitTestCase
+{
+    private \User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Create a test user
+        $this->user = new \User(
+            username: 'joedoe',
+            name: 'Joe Smith Doe',
+            email: 'joe@example.com',
+            photo: 'https://example.com/photo.jpg',
+            role: ROLE_PROF,
+            dummy: false
+        );
+    }
+
+    /**
+     * Test that user can be instantiated with correct properties
+     */
+    public function testUserCanBeCreated()
+    {
+        $this->assertInstanceOf(\User::class, $this->user);
+        $this->assertEquals('joedoe', $this->user->id);
+        $this->assertEquals('Joe Smith Doe', $this->user->name);
+        $this->assertEquals('joe@example.com', $this->user->email);
+    }
+
+    /**
+     * Test that user properties can be accessed
+     */
+    public function testUserPropertiesAreAccessible()
+    {
+        $this->assertEquals('joedoe', $this->user->id);
+        $this->assertEquals('Joe Smith Doe', $this->user->name);
+        $this->assertEquals('joe@example.com', $this->user->email);
+        $this->assertEquals('https://example.com/photo.jpg', $this->user->photo);
+        $this->assertEquals(ROLE_PROF, $this->user->role);
+    }
+
+    /**
+     * Test shortName() method returns first and last name
+     */
+    public function testShortNameReturnsFirstAndLastName()
+    {
+        $shortName = $this->user->shortName();
+        $this->assertStringStartsWith('Joe', $shortName);
+        $this->assertStringEndsWith('Doe', $shortName);
+    }
+
+    /**
+     * Test shortName() with single name
+     */
+    public function testShortNameWithSingleName()
+    {
+        $user = new \User('user', 'Madonna', 'madonna@example.com', '', ROLE_STUDENT, false);
+        $shortName = $user->shortName();
+        $this->assertStringContainsString('Madonna', $shortName);
+    }
+
+    /**
+     * Test shortName() with multiple name parts
+     */
+    public function testShortNameWithMultipleNameParts()
+    {
+        $user = new \User('user', 'Jean Claude Van Damme', 'jcvd@example.com', '', ROLE_STUDENT, false);
+        $shortName = $user->shortName();
+        $this->assertStringStartsWith('Jean', $shortName);
+        $this->assertStringEndsWith('Damme', $shortName);
+    }
+
+    /**
+     * Test isDummy() returns true for dummy users
+     */
+    public function testIsDummyReturnsTrueForDummyUsers()
+    {
+        $dummyUser = new \User('ist0000001', 'Dummy User', 'dummy@example.com', '', ROLE_STUDENT, true);
+        $this->assertTrue($dummyUser->isDummy());
+    }
+
+    /**
+     * Test isDummy() returns false for regular users
+     */
+    public function testIsDummyReturnsFalseForRegularUsers()
+    {
+        $this->assertFalse($this->user->isDummy());
+    }
+
+    /**
+     * Test isDummy() detects various dummy ID patterns
+     */
+    public function testIsDummyDetectsDummyIdPatterns()
+    {
+        $patterns = [
+            'ist0000000',
+            'ist0000001',
+            'ist0000999',
+            'ist0000abc',
+        ];
+
+        foreach ($patterns as $id) {
+            $user = new \User($id, 'User', 'email@example.com', '', ROLE_STUDENT, true);
+            $this->assertTrue($user->isDummy(), "ID $id should be detected as dummy");
+        }
+    }
+
+    /**
+     * Test __toString() returns user ID
+     */
+    public function testToStringReturnsUserId()
+    {
+        $this->assertEquals('joedoe', (string)$this->user);
+    }
+
+    /**
+     * Test getPhoto() returns provided photo when available
+     */
+    public function testGetPhotoReturnsProvidedPhoto()
+    {
+        $photo = 'https://example.com/my-photo.jpg';
+        $user = new \User('user', 'User', 'email@example.com', $photo, ROLE_STUDENT, false);
+        $this->assertEquals($photo, $user->getPhoto());
+    }
+
+    /**
+     * Test getPhoto() returns default Fenix photo when empty
+     */
+    public function testGetPhotoReturnsDefaultPhotoWhenEmpty()
+    {
+        $user = new \User('joedoe', 'Joe', 'joe@example.com', '', ROLE_STUDENT, false);
+        $photo = $user->getPhoto();
+        
+        $this->assertStringContainsString('fenix.tecnico.ulisboa.pt', $photo);
+        $this->assertStringContainsString('joedoe', $photo);
+        $this->assertStringStartsWith('https://', $photo);
+    }
+
+    /**
+     * Test roleAtLeast() returns true when user role is high enough
+     */
+    public function testRoleAtLeastReturnsTrueWhenRoleHighEnough()
+    {
+        $this->assertTrue($this->user->roleAtLeast(ROLE_PROF));
+    }
+
+    /**
+     * Test roleAtLeast() returns true when checking lower roles
+     */
+    public function testRoleAtLeastReturnsTrueForLowerRoles()
+    {
+        $this->assertTrue($this->user->roleAtLeast(ROLE_STUDENT));
+    }
+
+    /**
+     * Test roleAtLeast() returns false for higher roles
+     */
+    public function testRoleAtLeastReturnsFalseForHigherRoles()
+    {
+        $this->assertFalse($this->user->roleAtLeast(ROLE_SUDO));
+    }
+
+    /**
+     * Test getGroup() returns null when user has no groups
+     */
+    public function testGetGroupReturnsNullWhenNoGroups()
+    {
+        $user = new \User('user', 'User', 'email@example.com', '', ROLE_STUDENT, false);
+        $this->assertNull($user->getGroup());
+    }
+
+    /**
+     * Test getGroup() returns group for current year
+     */
+    public function testGetGroupReturnsCurrentYearGroup()
+    {
+        // Create shift and group with CURRENT year (not hardcoded)
+        $currentYear = get_current_year();
+        $shift = new \Shift('Monday 10:00', $currentYear);
+        $group = new \ProjGroup(1, $currentYear, $shift);
+        $group->project_name = 'Test Project';
+
+        $user = new \User('user', 'User', 'email@example.com', '', ROLE_STUDENT, false);
+        $user->groups->add($group);
+
+        // Should return the group with current year
+        $result = $user->getGroup();
+        $this->assertNotNull($result);
+        $this->assertEquals($currentYear, $result->year);
+    }
+
+    /**
+     * Test getGroup() returns the first year-descending group when there is no current-year match
+     */
+    public function testGetGroupReturnsFirstOrderedGroupWhenNoCurrentYearMatch()
+    {
+        $shift = new \Shift('Monday 10:00', 2024);
+        $oldGroup = new \ProjGroup(1, 2020, $shift);
+        $oldGroup->project_name = 'Old Project';
+        $newGroup = new \ProjGroup(2, 2023, $shift);
+        $newGroup->project_name = 'New Project';
+
+        $user = new \User('user', 'User', 'email@example.com', '', ROLE_STUDENT, false);
+        $user->groups->add($newGroup);
+        $user->groups->add($oldGroup);
+
+        $result = $user->getGroup();
+        $this->assertSame($newGroup, $result);
+    }
+
+    /**
+     * Test getYear() returns null when user has no groups
+     */
+    public function testGetYearReturnsNullWhenNoGroups()
+    {
+        $user = new \User('user', 'User', 'email@example.com', '', ROLE_STUDENT, false);
+        $this->assertNull($user->getYear());
+    }
+
+    /**
+     * Test getYear() returns year from user's group
+     */
+    public function testGetYearReturnsYearFromGroup()
+    {
+        $shift = new \Shift('Monday 10:00', 2024);
+        $group = new \ProjGroup(1, 2024, $shift);
+        $group->project_name = 'Test Project';
+
+        $user = new \User('user', 'User', 'email@example.com', '', ROLE_STUDENT, false);
+        $user->groups->add($group);
+
+        $this->assertEquals(2024, $user->getYear());
+    }
+
+    /**
+     * Test getRole() returns role string
+     */
+    public function testGetRoleReturnsRoleString()
+    {
+        $roleString = $this->user->getRole();
+        $this->assertIsString($roleString);
+        $this->assertEquals('Professor', $roleString);
+    }
+
+    /**
+     * Test getRole() for student role
+     */
+    public function testGetRoleForStudentRole()
+    {
+        $user = new \User('student', 'Student', 'student@example.com', '', ROLE_STUDENT, false);
+        $roleString = $user->getRole();
+        $this->assertEquals('Student', $roleString);
+    }
+
+    /**
+     * Test getRole() for TA role
+     */
+    public function testGetRoleForTARole()
+    {
+        $user = new \User('ta', 'TA', 'ta@example.com', '', ROLE_TA, false);
+        $roleString = $user->getRole();
+        $this->assertEquals('TA', $roleString);
+    }
+
+    /**
+     * Test getRepoUser() returns null when no repository user set
+     */
+    public function testGetRepoUserReturnsNullWhenNotSet()
+    {
+        $user = new \User('user', 'User', 'email@example.com', '', ROLE_STUDENT, false);
+        $user->repository_user = '';
+        $this->assertNull($user->getRepoUser());
+    }
+
+    /**
+     * Test getRepoUser() returns RepositoryUser when set
+     */
+    public function testGetRepoUserReturnsRepositoryUserWhenSet()
+    {
+        $user = new \User('user', 'User', 'email@example.com', '', ROLE_STUDENT, false);
+        $user->repository_user = 'github:username';
+        
+        $repoUser = $user->getRepoUser();
+        $this->assertNotNull($repoUser);
+        $this->assertInstanceOf(\RepositoryUser::class, $repoUser);
+        $this->assertEquals($user, $repoUser->user);
+    }
+
+    /**
+     * Test groups collection is ArrayCollection
+     */
+    public function testGroupsIsArrayCollection()
+    {
+        $this->assertInstanceOf(\Doctrine\Common\Collections\ArrayCollection::class, $this->user->groups);
+    }
+
+    /**
+     * Test repository_user default value is empty string
+     */
+    public function testRepositoryUserDefaultValue()
+    {
+        $user = new \User('user', 'User', 'email@example.com', '', ROLE_STUDENT, false);
+        $this->assertEquals('', $user->repository_user);
+    }
+
+    /**
+     * Test multiple users can have different groups
+     */
+    public function testMultipleUsersCanHaveDifferentGroups()
+    {
+        $shift = new \Shift('Monday 10:00', 2024);
+        $group1 = new \ProjGroup(1, 2024, $shift);
+        $group1->project_name = 'Project 1';
+        $group2 = new \ProjGroup(2, 2024, $shift);
+        $group2->project_name = 'Project 2';
+
+        $user1 = new \User('user1', 'User 1', 'user1@example.com', '', ROLE_STUDENT, false);
+        $user2 = new \User('user2', 'User 2', 'user2@example.com', '', ROLE_STUDENT, false);
+
+        $user1->groups->add($group1);
+        $user2->groups->add($group2);
+
+        $this->assertEquals($group1, $user1->getGroup());
+        $this->assertEquals($group2, $user2->getGroup());
+    }
+
+    /**
+     * Test set_repository_user() parses simple format
+     */
+    public function testSetRepositoryUserParsesSimpleFormat()
+    {
+        $user = new \User('user', 'User', 'email@example.com', '', ROLE_STUDENT, false);
+
+        $user->set_repository_user('github:username');
+
+        $this->assertEquals('github:username', $user->repository_user);
+    }
+
+    /**
+     * Test set_repository_user() resets on ValidationException for invalid format
+     */
+    public function testSetRepositoryUserResetOnInvalidFormat()
+    {
+        $user = new \User('user', 'User', 'email@example.com', '', ROLE_STUDENT, false);
+        $user->repository_user = 'old-value';
+        
+        try {
+            // Invalid format (no colon separator)
+            $user->set_repository_user('invalidformat');
+            $this->fail('Should throw ValidationException for invalid format');
+        } catch (\ValidationException $e) {
+            // Should be reset to empty string when exception occurs
+            $this->assertEquals('', $user->repository_user);
+            $this->assertStringContainsString('provider:username', $e->getMessage());
+        }
+    }
+
+    /**
+     * Test set_repository_user() resets on invalid platform
+     */
+    public function testSetRepositoryUserResetOnInvalidPlatform()
+    {
+        $user = new \User('user', 'User', 'email@example.com', '', ROLE_STUDENT, false);
+        $user->repository_user = 'old-value';
+        
+        try {
+            // Invalid platform
+            $user->set_repository_user('gitlab:username');
+            $this->fail('Should throw ValidationException for unsupported platform');
+        } catch (\ValidationException $e) {
+            $this->assertEquals('', $user->repository_user);
+            $this->assertStringContainsString('platform', $e->getMessage());
+        }
+    }
+
+    /**
+     * Test set_repository_user() handles URL parsing
+     */
+    public function testSetRepositoryUserHandlesUrlParsing()
+    {
+        $user = new \User('user', 'User', 'email@example.com', '', ROLE_STUDENT, false);
+
+        $user->set_repository_user('https://github.com/validuser');
+
+        $this->assertEquals('github:validuser', $user->repository_user);
+    }
+
+    /**
+     * Test set_repository_user() resets value on exception
+     */
+    public function testSetRepositoryUserResetsOnException()
+    {
+        $user = new \User('user', 'User', 'email@example.com', '', ROLE_STUDENT, false);
+        $originalValue = 'github:original';
+        $user->repository_user = $originalValue;
+        
+        try {
+            // Try invalid format that will definitely throw
+            $user->set_repository_user('bad_format_no_colon');
+            $this->fail('Should throw ValidationException for invalid format');
+        } catch (\ValidationException $e) {
+            // Verify the value was reset to empty, not left at original
+            $this->assertNotEquals($originalValue, $user->repository_user);
+            $this->assertEquals('', $user->repository_user);
+            $this->assertStringContainsString('provider:username', $e->getMessage());
+        }
+    }
+
+    /**
+     * Test set_repository_user() with valid format and no group
+     */
+    public function testSetRepositoryUserValidFormatNoGroup()
+    {
+        $user = new \User('user', 'User', 'email@example.com', '', ROLE_STUDENT, false);
+
+        $user->set_repository_user('github:testuser');
+
+        $this->assertEquals('github:testuser', $user->repository_user);
+    }
+
+    /**
+     * Test repository_user property defaults to empty string
+     */
+    public function testRepositoryUserDefaultsToEmptyString()
+    {
+        $this->assertEquals('', $this->user->repository_user);
+    }
+
+    /**
+     * Test repository_etag property defaults to empty string
+     */
+    public function testRepositoryEtagDefaultsToEmptyString()
+    {
+        $this->assertEquals('', $this->user->repository_etag);
+    }
+
+    /**
+     * Test repository_last_processed_id defaults to zero
+     */
+    public function testRepositoryLastProcessedIdDefaultsToZero()
+    {
+        $this->assertEquals('0', $this->user->repository_last_processed_id);
+    }
+
+    /**
+     * Test groups collection is initialized
+     */
+    public function testGroupsCollectionIsInitialized()
+    {
+        $this->assertNotNull($this->user->groups);
+        $this->assertInstanceOf(\Doctrine\Common\Collections\Collection::class, $this->user->groups);
+        $this->assertTrue($this->user->groups->isEmpty());
+    }
+
+    /**
+     * Test user email is stored correctly
+     */
+    public function testEmailIsStoredCorrectly()
+    {
+        $this->assertEquals('joe@example.com', $this->user->email);
+        
+        $user2 = new \User('user', 'User', 'another@test.org', '', ROLE_STUDENT, false);
+        $this->assertEquals('another@test.org', $user2->email);
+    }
+
+    /**
+     * Test user role is stored correctly
+     */
+    public function testRoleIsStoredCorrectly()
+    {
+        $this->assertEquals(ROLE_PROF, $this->user->role);
+        
+        $sudoUser = new \User('admin', 'Admin', 'admin@example.com', '', ROLE_SUDO, false);
+        $this->assertEquals(ROLE_SUDO, $sudoUser->role);
+    }
+
+    /**
+     * Test that user constructor accepts dummy parameter
+     */
+    public function testConstructorAcceptsDummyParameter()
+    {
+        $user1 = new \User('user1', 'User', 'user@example.com', '', ROLE_STUDENT, false);
+        $this->assertFalse($user1->isDummy());
+
+        $user2 = new \User('ist0000001', 'Dummy', 'dummy@example.com', '', ROLE_STUDENT, true);
+        $this->assertTrue($user2->isDummy());
+    }
+
+    /**
+     * Test that different users have different instances
+     */
+    public function testDifferentUsersAreDifferentInstances()
+    {
+        $user1 = new \User('user1', 'User One', 'user1@example.com', '', ROLE_STUDENT, false);
+        $user2 = new \User('user2', 'User Two', 'user2@example.com', '', ROLE_STUDENT, false);
+
+        $this->assertNotSame($user1, $user2);
+        $this->assertNotEquals($user1->id, $user2->id);
+    }
+
+    /**
+     * Test user can be updated after creation
+     */
+    public function testUserPropertiesCanBeUpdated()
+    {
+        $originalName = $this->user->name;
+        $this->user->name = 'Jane Doe';
+        
+        $this->assertNotEquals($originalName, $this->user->name);
+        $this->assertEquals('Jane Doe', $this->user->name);
+    }
+
+    /**
+     * Test email validation format
+     */
+    public function testEmailFormatExamples()
+    {
+        $validEmails = [
+            'user@example.com',
+            'john.doe@company.co.uk',
+            'test123@domain.org',
+            'first.last+tag@subdomain.example.com',
+        ];
+
+        foreach ($validEmails as $email) {
+            $user = new \User('user', 'User', $email, '', ROLE_STUDENT, false);
+            $this->assertEquals($email, $user->email);
+        }
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,63 @@
+<?php
+// Bootstrap file for PHPUnit tests
+
+use Tests\Mocks\MockGitHubClient;
+
+// Load Composer autoloader
+require_once dirname(__DIR__) . '/vendor/autoload.php';
+
+// Load project includes
+require_once dirname(__DIR__) . '/include.php';
+
+// Load validation and database functions required by entity tests
+require_once dirname(__DIR__) . '/validation.php';
+require_once dirname(__DIR__) . '/db.php';
+require_once dirname(__DIR__) . '/video.php';
+
+// Define test environment
+define('TEST_MODE', true);
+
+// Define helper functions from auth.php needed for User tests
+function auth_user_at_least(User $user, $role) {
+    return $user->role <= $role;
+}
+
+function get_all_roles($include_sudo) {
+    $roles = [
+        1 => 'Professor',    // ROLE_PROF
+        2 => 'TA',           // ROLE_TA
+        3 => 'Student'       // ROLE_STUDENT
+    ];
+    if ($include_sudo)
+        $roles[0] = 'Sudo';  // ROLE_SUDO
+    return $roles;
+}
+
+// Define helper functions from fenix.php needed for User tests
+function get_current_year() {
+    $year = (int)date('Y');
+    return date('n') >= 9 ? $year : ($year-1);  // MONTH_NEW_YEAR = 9
+}
+
+// Define helper functions needed by entity tests
+function format_big_number($n) {
+    if ($n < 1000)
+        return $n;
+    if ($n < 1000000)
+        return round($n / 1000) . "\u{202F}k";
+    return round($n / 1000000, 1) . "\u{202F}M";
+}
+
+function github_parse_date($date) {
+    if ($ret = \DateTimeImmutable::createFromFormat('Y-m-d\TH:i:sp', $date))
+        return $ret;
+    throw new Exception("Couldn't parse github date: $date");
+}
+
+// Set reusable fake clients as globals for entity code to access.
+$GLOBALS['github_client_cached'] = new MockGitHubClient();
+$GLOBALS['github_client'] = new MockGitHubClient();
+
+// Suppress output from config loading if needed
+error_reporting(E_ALL);
+ini_set('display_errors', '1');


### PR DESCRIPTION
Added a PHPUnit-based test structure for the repository. This includes the required setup to run automated tests and generate coverage reports for the project.

The new structure makes it easier to validate future changes and inspect which parts of the codebase are covered by tests.

Co-authored-by: Gil Silva <gil.m.silva@tecnico.ulisboa.pt>